### PR TITLE
chore: remove unused Save icon import

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -6,12 +6,11 @@ import {
   Play, 
   Pause, 
   RotateCcw, 
-  Plus, 
-  Minus, 
-  Settings, 
+  Plus,
+  Minus,
+  Settings,
   Upload,
   Monitor,
-  Save,
   BarChart3,
   Timer
 } from 'lucide-react';


### PR DESCRIPTION
## Summary
- remove unused `Save` icon import from `Dashboard`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 8 errors across repository)


------
https://chatgpt.com/codex/tasks/task_e_6890dcd4dbc4832d81140d106ba9cb6a