### PR TITLE
refactor: extract control panel button component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { Dashboard } from './components/Dashboard';
 import { Overlay } from './components/Overlay';
 import { StatsTracker } from './components/StatsTracker';
 import { PossessionTracker } from './components/PossessionTracker';
+import { ControlPanelButton } from './components/ControlPanelButton';
 
 type ViewMode = 'scoreboard' | 'dashboard' | 'overlay' | 'stats' | 'possession';
 
@@ -22,52 +23,32 @@ function App() {
         <div className="relative min-h-screen bg-transparent">
           <Overlay gameState={gameState.gameState} />
           {/* Floating control button */}
-          <button
-            onClick={() => setViewMode('dashboard')}
-            className="fixed top-4 right-4 bg-black/50 text-white px-4 py-2 rounded-lg hover:bg-black/70 transition-colors backdrop-blur-sm z-50"
-          >
-            Control Panel
-          </button>
+          <ControlPanelButton onClick={() => setViewMode('dashboard')} />
         </div>
       ) : viewMode === 'stats' ? (
         <div className="relative">
-          <StatsTracker 
+          <StatsTracker
             gameState={gameState.gameState}
             updateTeamStats={gameState.updateTeamStats}
             switchBallPossession={gameState.switchBallPossession}
           />
           {/* Floating control button */}
-          <button
-            onClick={() => setViewMode('dashboard')}
-            className="fixed top-4 right-4 bg-black/50 text-white px-4 py-2 rounded-lg hover:bg-black/70 transition-colors backdrop-blur-sm z-50"
-          >
-            Control Panel
-          </button>
+          <ControlPanelButton onClick={() => setViewMode('dashboard')} />
         </div>
       ) : viewMode === 'scoreboard' ? (
         <div className="relative">
           <Scoreboard gameState={gameState.gameState} />
           {/* Floating control button */}
-          <button
-            onClick={() => setViewMode('dashboard')}
-            className="fixed top-4 right-4 bg-black/50 text-white px-4 py-2 rounded-lg hover:bg-black/70 transition-colors backdrop-blur-sm z-50"
-          >
-            Control Panel
-          </button>
+          <ControlPanelButton onClick={() => setViewMode('dashboard')} />
         </div>
       ) : viewMode === 'possession' ? (
         <div className="relative">
-          <PossessionTracker 
+          <PossessionTracker
             gameState={gameState.gameState}
             switchBallPossession={gameState.switchBallPossession}
           />
           {/* Floating control button */}
-          <button
-            onClick={() => setViewMode('dashboard')}
-            className="fixed top-4 right-4 bg-black/50 text-white px-4 py-2 rounded-lg hover:bg-black/70 transition-colors backdrop-blur-sm z-50"
-          >
-            Control Panel
-          </button>
+          <ControlPanelButton onClick={() => setViewMode('dashboard')} />
         </div>
       ) : (
         <Dashboard

--- a/src/components/ControlPanelButton.tsx
+++ b/src/components/ControlPanelButton.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface ControlPanelButtonProps {
+  onClick: () => void;
+}
+
+export const ControlPanelButton: React.FC<ControlPanelButtonProps> = ({ onClick }) => (
+  <button
+    onClick={onClick}
+    className="fixed top-4 right-4 bg-black/50 text-white px-4 py-2 rounded-lg hover:bg-black/70 transition-colors backdrop-blur-sm z-50"
+  >
+    Control Panel
+  </button>
+);
+


### PR DESCRIPTION
## Summary
- add reusable `ControlPanelButton` component
- replace repeated control button across view modes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 9 problems)*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6890d9f3fde8832d91f44f6a6cfe5e8b