### PR TITLE
refactor: reuse possession switch function

### DIFF
--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { GameState, Team } from '../types';
-import { GAME_PRESETS, shouldAutoAdvance, getPresetByType } from '../utils/gamePresets';
+import { GAME_PRESETS, shouldAutoAdvance } from '../utils/gamePresets';
 
 const initialState: GameState = {
   homeTeam: {
@@ -200,90 +200,12 @@ export const useGameState = () => {
         case 'KeyD':
         case 'Digit1':
           event.preventDefault();
-          // Only allow possession switching when timer is running
-          setGameState(prev => {
-            if (prev.isRunning) {
-              const now = Date.now();
-              const timeDiff = now - prev.possessionStartTime;
-              
-              // Update possession time for previous team
-              const updatedPossessionTime = {
-                ...prev.totalPossessionTime,
-                [prev.ballPossession]: prev.totalPossessionTime[prev.ballPossession] + timeDiff,
-              };
-              
-              // Calculate possession percentages
-              const totalTime = updatedPossessionTime.home + updatedPossessionTime.away;
-              const homePossession = totalTime > 0 ? Math.round((updatedPossessionTime.home / totalTime) * 100) : 50;
-              const awayPossession = 100 - homePossession;
-              
-              return {
-                ...prev,
-                ballPossession: 'home',
-                possessionStartTime: now,
-                totalPossessionTime: updatedPossessionTime,
-                homeTeam: {
-                  ...prev.homeTeam,
-                  stats: {
-                    ...prev.homeTeam.stats,
-                    possession: homePossession,
-                  },
-                },
-                awayTeam: {
-                  ...prev.awayTeam,
-                  stats: {
-                    ...prev.awayTeam.stats,
-                    possession: awayPossession,
-                  },
-                },
-              };
-            }
-            return prev;
-          });
+          switchBallPossession('home');
           break;
         case 'KeyA':
         case 'Digit2':
           event.preventDefault();
-          // Only allow possession switching when timer is running
-          setGameState(prev => {
-            if (prev.isRunning) {
-              const now = Date.now();
-              const timeDiff = now - prev.possessionStartTime;
-              
-              // Update possession time for previous team
-              const updatedPossessionTime = {
-                ...prev.totalPossessionTime,
-                [prev.ballPossession]: prev.totalPossessionTime[prev.ballPossession] + timeDiff,
-              };
-              
-              // Calculate possession percentages
-              const totalTime = updatedPossessionTime.home + updatedPossessionTime.away;
-              const homePossession = totalTime > 0 ? Math.round((updatedPossessionTime.home / totalTime) * 100) : 50;
-              const awayPossession = 100 - homePossession;
-              
-              return {
-                ...prev,
-                ballPossession: 'away',
-                possessionStartTime: now,
-                totalPossessionTime: updatedPossessionTime,
-                homeTeam: {
-                  ...prev.homeTeam,
-                  stats: {
-                    ...prev.homeTeam.stats,
-                    possession: homePossession,
-                  },
-                },
-                awayTeam: {
-                  ...prev.awayTeam,
-                  stats: {
-                    ...prev.awayTeam.stats,
-                    possession: awayPossession,
-                  },
-                },
-              };
-            }
-            return prev;
-          });
+          switchBallPossession('away');
           break;
       }
     };


### PR DESCRIPTION
## Summary
- simplify possession keyboard shortcuts by reusing `switchBallPossession`
- drop unused `getPresetByType` import

## Testing
- `npm run lint` *(fails: Dashboard.tsx Settings is defined but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6890d9f49148832da62f0978287dc21b