### PR TITLE
Use preset name for GamePresetSelector keys

### DIFF
--- a/src/components/GamePresetSelector.tsx
+++ b/src/components/GamePresetSelector.tsx
@@ -32,7 +32,7 @@ export const GamePresetSelector: React.FC<GamePresetSelectorProps> = ({
           
           return (
             <button
-              key={index}
+              key={preset.name}
               onClick={() => onPresetChange(index)}
               className={`p-4 rounded-lg border-2 text-left transition-all hover:shadow-md ${
                 isSelected


### PR DESCRIPTION
## Summary
- ensure unique React keys in GamePresetSelector by using preset.name instead of list index

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 9 errors)*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6890d9f5c1c8832d8d9205feff147296