### PR TITLE
refactor: centralize formatting helpers

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -3,15 +3,13 @@ import { GameState, Team } from '../types';
 import { ExternalControlInfo } from './ExternalControlInfo';
 import { GamePresetSelector } from './GamePresetSelector';
 import { 
-  Play, 
-  Pause, 
-  RotateCcw, 
-  Plus, 
-  Minus, 
-  Settings, 
+  Play,
+  Pause,
+  RotateCcw,
+  Plus,
+  Minus,
   Upload,
   Monitor,
-  Save,
   BarChart3,
   Timer
 } from 'lucide-react';
@@ -35,8 +33,6 @@ export const Dashboard: React.FC<DashboardProps> = ({
   gameState,
   updateTeam,
   updateTournamentLogo,
-  updateTeamStats,
-  switchBallPossession,
   updateTime,
   toggleTimer,
   resetTimer,
@@ -44,8 +40,14 @@ export const Dashboard: React.FC<DashboardProps> = ({
   changeGamePreset,
   resetGame,
   onViewChange,
-}) => {
+  }) => {
   const [activeTab, setActiveTab] = useState<'teams' | 'timer' | 'format' | 'settings'>('teams');
+  const tabs: Array<'teams' | 'timer' | 'format' | 'settings'> = [
+    'teams',
+    'timer',
+    'format',
+    'settings',
+  ];
 
   const handleImageUpload = (team: 'home' | 'away', event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -148,10 +150,10 @@ export const Dashboard: React.FC<DashboardProps> = ({
         <div className="mb-8">
           <div className="border-b border-gray-200">
             <nav className="-mb-px flex space-x-8">
-              {['teams', 'timer', 'format', 'settings'].map((tab) => (
+              {tabs.map(tab => (
                 <button
                   key={tab}
-                  onClick={() => setActiveTab(tab as any)}
+                  onClick={() => setActiveTab(tab)}
                   className={`py-2 px-1 border-b-2 font-medium text-sm capitalize transition-colors ${
                     activeTab === tab
                       ? 'border-green-500 text-green-600'

--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -2,22 +2,14 @@ import React from 'react';
 import { GameState } from '../types';
 import { getHalfName } from '../utils/gamePresets';
 import { Crown } from 'lucide-react';
+import { formatTime, isWinning } from '../utils/formatters';
 
 interface OverlayProps {
   gameState: GameState;
 }
 
 export const Overlay: React.FC<OverlayProps> = ({ gameState }) => {
-  const { homeTeam, awayTeam, time, half } = gameState;
-  
-  const formatTime = (minutes: number, seconds: number) => {
-    return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
-  };
-
-  const isWinning = (teamScore: number, opponentScore: number) => {
-    return teamScore > opponentScore;
-  };
-
+  const { homeTeam, awayTeam, time } = gameState;
 
   return (
     <div className="fixed inset-0 pointer-events-none">

--- a/src/components/Scoreboard.tsx
+++ b/src/components/Scoreboard.tsx
@@ -2,21 +2,14 @@ import React from 'react';
 import { GameState } from '../types';
 import { getHalfName } from '../utils/gamePresets';
 import { Crown } from 'lucide-react';
+import { formatTime, isWinning } from '../utils/formatters';
 
 interface ScoreboardProps {
   gameState: GameState;
 }
 
 export const Scoreboard: React.FC<ScoreboardProps> = ({ gameState }) => {
-  const { homeTeam, awayTeam, time, half } = gameState;
-  
-  const formatTime = (minutes: number, seconds: number) => {
-    return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
-  };
-
-  const isWinning = (score1: number, score2: number) => {
-    return score1 > score2;
-  };
+  const { homeTeam, awayTeam, time } = gameState;
 
   return (
     <div className="w-screen h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 text-white flex items-center justify-center overflow-hidden">

--- a/src/components/StatsTracker.tsx
+++ b/src/components/StatsTracker.tsx
@@ -4,11 +4,10 @@ import {
   Plus, 
   Minus, 
   Target, 
-  CornerDownLeft, 
-  Flag, 
+  CornerDownLeft,
+  Flag,
   AlertTriangle,
   Square,
-  Users,
   Timer
 } from 'lucide-react';
 

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { GameState, Team } from '../types';
-import { GAME_PRESETS, shouldAutoAdvance, getPresetByType } from '../utils/gamePresets';
+import { GAME_PRESETS, shouldAutoAdvance } from '../utils/gamePresets';
 
 const initialState: GameState = {
   homeTeam: {

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,0 +1,10 @@
+export const formatTime = (minutes: number, seconds: number): string => {
+  return `${minutes.toString().padStart(2, '0')}:${seconds
+    .toString()
+    .padStart(2, '0')}`;
+};
+
+export const isWinning = (score: number, opponentScore: number): boolean => {
+  return score > opponentScore;
+};
+


### PR DESCRIPTION
## Summary
- add `formatTime` and `isWinning` helpers to `utils`
- use shared helpers in `Scoreboard` and `Overlay`
- clean up unused imports and props to satisfy lint

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890d9f725b4832d8b0ec6f70d5f379b