### PR TITLE
Use browser-friendly interval type

### DIFF
--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { GameState, Team } from '../types';
-import { GAME_PRESETS, shouldAutoAdvance, getPresetByType } from '../utils/gamePresets';
+import { GAME_PRESETS, shouldAutoAdvance } from '../utils/gamePresets';
 
 const initialState: GameState = {
   homeTeam: {
@@ -49,7 +49,7 @@ const initialState: GameState = {
 
 export const useGameState = () => {
   const [gameState, setGameState] = useState<GameState>(initialState);
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const keyboardListenerRef = useRef<((event: KeyboardEvent) => void) | null>(null);
 
   const updateTeam = useCallback((team: 'home' | 'away', field: 'name' | 'score' | 'fouls' | 'logo', value: string | number) => {


### PR DESCRIPTION
## Summary
- replace NodeJS timeout reference with ReturnType<typeof setInterval>
- remove unused game preset helper import

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 9 errors in existing files)*
- `npx eslint src/hooks/useGameState.ts`

------
https://chatgpt.com/codex/tasks/task_e_6890dcd130f4832d83f039994e63fd17