### PR TITLE
refactor: remove unused getPresetByType import

### DIFF
--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { GameState, Team } from '../types';
-import { GAME_PRESETS, shouldAutoAdvance, getPresetByType } from '../utils/gamePresets';
+import { GAME_PRESETS, shouldAutoAdvance } from '../utils/gamePresets';
 
 const initialState: GameState = {
   homeTeam: {


### PR DESCRIPTION
## Summary
- remove unused getPresetByType import from useGameState hook

## Testing
- `npm run lint` *(fails: 8 errors in unrelated components)*
- `npx eslint src/hooks/useGameState.ts`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6890dcd27664832d9fb6c83d690afdf9