### PR TITLE
Remove unnecessary half destructuring in overlay

### DIFF
--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -8,7 +8,7 @@ interface OverlayProps {
 }
 
 export const Overlay: React.FC<OverlayProps> = ({ gameState }) => {
-  const { homeTeam, awayTeam, time, half } = gameState;
+  const { homeTeam, awayTeam, time } = gameState;
   
   const formatTime = (minutes: number, seconds: number) => {
     return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;


### PR DESCRIPTION
## Summary
- avoid destructuring `half` in `Overlay` component and rely on `gameState.half`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: existing lint errors in other files)
- `npx eslint src/components/Overlay.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890dcd2e9f4832db8c5fc5592a2de3b