### PR TITLE
refactor: use gameState half directly

### DIFF
--- a/src/components/Scoreboard.tsx
+++ b/src/components/Scoreboard.tsx
@@ -8,7 +8,7 @@ interface ScoreboardProps {
 }
 
 export const Scoreboard: React.FC<ScoreboardProps> = ({ gameState }) => {
-  const { homeTeam, awayTeam, time, half } = gameState;
+  const { homeTeam, awayTeam, time } = gameState;
   
   const formatTime = (minutes: number, seconds: number) => {
     return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;


### PR DESCRIPTION
## Summary
- remove `half` from `gameState` destructure in `Scoreboard`
- continue using `gameState.half` when deriving half name

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: lint errors in other files)*
- `npx eslint src/components/Scoreboard.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6890dcd3acfc832d93e32a3b483beea3