### PR TITLE
Swap possession hotkeys

### DIFF
--- a/src/components/ExternalControlInfo.tsx
+++ b/src/components/ExternalControlInfo.tsx
@@ -31,11 +31,11 @@ export const ExternalControlInfo: React.FC = () => {
             </div>
             <div className="flex justify-between">
               <span className="text-gray-600">Home Possession:</span>
-              <kbd className="bg-gray-100 px-2 py-1 rounded">D or 1</kbd>
+              <kbd className="bg-gray-100 px-2 py-1 rounded">A or 1</kbd>
             </div>
             <div className="flex justify-between">
               <span className="text-gray-600">Away Possession:</span>
-              <kbd className="bg-gray-100 px-2 py-1 rounded">A or 2</kbd>
+              <kbd className="bg-gray-100 px-2 py-1 rounded">D or 2</kbd>
             </div>
             <div className="text-xs text-gray-500 mt-2">
               * Possession shortcuts only work when timer is running

--- a/src/components/PossessionTracker.tsx
+++ b/src/components/PossessionTracker.tsx
@@ -90,7 +90,7 @@ export const PossessionTracker: React.FC<PossessionTrackerProps> = ({
                   )}
                 </div>
                 <div className="font-bold text-lg mb-2">{homeTeam.name}</div>
-                <div className="text-sm">Click for Possession (D or 1)</div>
+                <div className="text-sm">Click for Possession (A or 1)</div>
                 <div className="text-2xl font-bold">{homeTeam.stats.possession}%</div>
                 {ballPossession === 'home' && (
                   <div className="mt-2 text-xs font-semibold text-blue-600">
@@ -189,7 +189,7 @@ export const PossessionTracker: React.FC<PossessionTrackerProps> = ({
           <h4 className="font-semibold text-green-900 mb-3">Operator Instructions</h4>
           <ul className="space-y-2 text-sm text-green-800">
             <li>• <strong>Click team buttons</strong> to switch ball possession when play changes</li>
-            <li>• <strong>Keyboard shortcuts</strong>: Press <kbd className="bg-green-100 px-2 py-1 rounded text-xs">D</kbd> or <kbd className="bg-green-100 px-2 py-1 rounded text-xs">1</kbd> for Home team, <kbd className="bg-green-100 px-2 py-1 rounded text-xs">A</kbd> or <kbd className="bg-green-100 px-2 py-1 rounded text-xs">2</kbd> for Away team</li>
+            <li>• <strong>Keyboard shortcuts</strong>: Press <kbd className="bg-green-100 px-2 py-1 rounded text-xs">A</kbd> or <kbd className="bg-green-100 px-2 py-1 rounded text-xs">1</kbd> for Home team, <kbd className="bg-green-100 px-2 py-1 rounded text-xs">D</kbd> or <kbd className="bg-green-100 px-2 py-1 rounded text-xs">2</kbd> for Away team</li>
             <li>• <strong>Shortcuts only work when timer is running</strong> - prevents accidental possession changes during breaks</li>
             <li>• <strong>Possession percentages</strong> are calculated automatically based on time</li>
             <li>• <strong>Only track possession changes</strong> - other operators handle different stats</li>

--- a/src/components/StatsTracker.tsx
+++ b/src/components/StatsTracker.tsx
@@ -129,7 +129,7 @@ export const StatsTracker: React.FC<StatsTrackerProps> = ({
             >
               <div className="text-center">
                 <div className="font-semibold">{homeTeam.name}</div>
-                <div className="text-sm">Has Possession (D or 1)</div>
+                <div className="text-sm">Has Possession (A or 1)</div>
                 <div className="text-lg font-bold mt-1">{homeTeam.stats.possession}%</div>
               </div>
             </button>
@@ -147,7 +147,7 @@ export const StatsTracker: React.FC<StatsTrackerProps> = ({
                 {ballPossession === 'home' ? homeTeam.name : awayTeam.name}
               </div>
               <div className="mt-2 text-xs text-gray-500">
-                Press D/1 for Home, A/2 for Away (only when timer running)
+                Press A/1 for Home, D/2 for Away (only when timer running)
               </div>
             </div>
 
@@ -161,7 +161,7 @@ export const StatsTracker: React.FC<StatsTrackerProps> = ({
             >
               <div className="text-center">
                 <div className="font-semibold">{awayTeam.name}</div>
-                <div className="text-sm">Has Possession (A or 2)</div>
+                <div className="text-sm">Has Possession (D or 2)</div>
                 <div className="text-lg font-bold mt-1">{awayTeam.stats.possession}%</div>
               </div>
             </button>

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -204,12 +204,12 @@ export const useGameState = () => {
           event.preventDefault();
           setGameState(prev => ({ ...prev, isRunning: false }));
           break;
-        case 'KeyD':
+        case 'KeyA':
         case 'Digit1':
           event.preventDefault();
           switchBallPossession('home');
           break;
-        case 'KeyA':
+        case 'KeyD':
         case 'Digit2':
           event.preventDefault();
           switchBallPossession('away');


### PR DESCRIPTION
## Summary
- Switch home possession hotkey to **A** and away to **D**
- Update on-screen instructions and external control info for new hotkeys

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890e73f767c832db0f668e2883f6386