### PR TITLE
Clarify away possession hotkeys

### DIFF
--- a/src/components/PossessionTracker.tsx
+++ b/src/components/PossessionTracker.tsx
@@ -143,7 +143,7 @@ export const PossessionTracker: React.FC<PossessionTrackerProps> = ({
                   )}
                 </div>
                 <div className="font-bold text-lg mb-2">{awayTeam.name}</div>
-                <div className="text-sm mb-2">Click for Possession</div>
+                <div className="text-sm mb-2">Click for Possession (D or 2)</div>
                 <div className="text-2xl font-bold">{awayTeam.stats.possession}%</div>
                 {ballPossession === 'away' && (
                   <div className="mt-2 text-xs font-semibold text-red-600">


### PR DESCRIPTION
## Summary
- Clarify away team's possession control with D or 2 hotkey hint

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890e9d2355c832dae7a6e4bcdf6e3ab