### PR TITLE
feat: toggle overlay stats bar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,17 +11,19 @@ type ViewMode = 'scoreboard' | 'dashboard' | 'overlay' | 'stats' | 'possession';
 
 function App() {
   const [viewMode, setViewMode] = useState<ViewMode>('dashboard');
+  const [showStats, setShowStats] = useState(false);
   const gameState = useGameState();
 
-  const handleViewChange = (view: ViewMode) => {
+  const handleViewChange = (view: ViewMode, stats: boolean = false) => {
     setViewMode(view);
+    setShowStats(stats);
   };
 
   return (
     <div className="App">
       {viewMode === 'overlay' ? (
         <div className="relative min-h-screen bg-transparent">
-          <Overlay gameState={gameState.gameState} />
+          <Overlay gameState={gameState.gameState} showStats={showStats} />
           {/* Floating control button */}
           <ControlPanelButton onClick={() => setViewMode('dashboard')} />
         </div>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -24,7 +24,10 @@ interface DashboardProps {
   updatePeriod: (period: number) => void;
   changeGamePreset: (presetIndex: number) => void;
   resetGame: () => void;
-  onViewChange: (view: 'scoreboard' | 'dashboard' | 'overlay' | 'stats' | 'possession') => void;
+  onViewChange: (
+    view: 'scoreboard' | 'dashboard' | 'overlay' | 'stats' | 'possession',
+    showStats?: boolean
+  ) => void;
 }
 
 export const Dashboard: React.FC<DashboardProps> = ({
@@ -113,7 +116,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
                 View Scoreboard
               </button>
               <button
-                onClick={() => onViewChange('overlay')}
+                onClick={() => onViewChange('overlay', true)}
                 className="inline-flex items-center gap-2 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors"
               >
                 <Monitor className="w-4 h-4" />

--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -5,9 +5,10 @@ import { Crown } from 'lucide-react';
 
 interface OverlayProps {
   gameState: GameState;
+  showStats?: boolean;
 }
 
-export const Overlay: React.FC<OverlayProps> = ({ gameState }) => {
+export const Overlay: React.FC<OverlayProps> = ({ gameState, showStats = false }) => {
   const { homeTeam, awayTeam, time } = gameState;
   
   const formatTime = (minutes: number, seconds: number) => {
@@ -97,29 +98,31 @@ export const Overlay: React.FC<OverlayProps> = ({ gameState }) => {
       </div>
 
       {/* Bottom Stats Bar (Optional - can be toggled) */}
-      <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 z-50">
-        <div className="bg-black/60 backdrop-blur-md rounded-xl border border-white/10 px-6 py-2">
-          <div className="flex items-center gap-8 text-sm">
-            <div className="flex items-center gap-2">
-              <span className="text-blue-400 font-medium">{homeTeam.name}</span>
-              <span className="text-white/60">Fouls:</span>
-              <span className="text-red-400 font-bold">{homeTeam.fouls}</span>
-              <span className="text-white/60">|</span>
-              <span className="text-white/60">Poss:</span>
-              <span className="text-blue-400 font-bold">{homeTeam.stats.possession}%</span>
-            </div>
-            <div className="w-px h-4 bg-white/20"></div>
-            <div className="flex items-center gap-2">
-              <span className="text-red-400 font-medium">{awayTeam.name}</span>
-              <span className="text-white/60">Fouls:</span>
-              <span className="text-red-400 font-bold">{awayTeam.fouls}</span>
-              <span className="text-white/60">|</span>
-              <span className="text-white/60">Poss:</span>
-              <span className="text-red-400 font-bold">{awayTeam.stats.possession}%</span>
+      {showStats && (
+        <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 z-50">
+          <div className="bg-black/60 backdrop-blur-md rounded-xl border border-white/10 px-6 py-2">
+            <div className="flex items-center gap-8 text-sm">
+              <div className="flex items-center gap-2">
+                <span className="text-blue-400 font-medium">{homeTeam.name}</span>
+                <span className="text-white/60">Fouls:</span>
+                <span className="text-red-400 font-bold">{homeTeam.fouls}</span>
+                <span className="text-white/60">|</span>
+                <span className="text-white/60">Poss:</span>
+                <span className="text-blue-400 font-bold">{homeTeam.stats.possession}%</span>
+              </div>
+              <div className="w-px h-4 bg-white/20"></div>
+              <div className="flex items-center gap-2">
+                <span className="text-red-400 font-medium">{awayTeam.name}</span>
+                <span className="text-white/60">Fouls:</span>
+                <span className="text-red-400 font-bold">{awayTeam.fouls}</span>
+                <span className="text-white/60">|</span>
+                <span className="text-white/60">Poss:</span>
+                <span className="text-red-400 font-bold">{awayTeam.stats.possession}%</span>
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add optional `showStats` prop to `Overlay` to hide or show bottom stats bar
- manage `showStats` state in `App` and allow `Dashboard` to specify when switching views

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890ee3a5eb8832d94ce23ffe209e277