### PR TITLE
Restrict extra-time options based on football match format

### DIFF
--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -155,10 +155,54 @@ export const useGameState = () => {
   }, []);
 
   const updatePeriod = useCallback((period: number) => {
-    setGameState(prev => ({
-      ...prev,
-      half: period,
-    }));
+    setGameState(prev => {
+      const preset = prev.gamePreset;
+      let newHalf = period;
+      let newPhase: GameState['matchPhase'] = prev.matchPhase;
+      let minutes = prev.time.minutes;
+      let seconds = prev.time.seconds;
+
+      if (preset.hasExtraTime) {
+        if (period <= 2) {
+          newPhase = 'regular';
+          minutes = preset.halfDuration;
+          seconds = 0;
+        } else if (period === 3 || period === 4) {
+          newPhase = 'extra-time';
+          minutes = preset.extraTimeDuration;
+          seconds = 0;
+        } else if (preset.hasPenalties) {
+          newHalf = 5;
+          newPhase = 'penalties';
+          minutes = 0;
+          seconds = 0;
+        } else {
+          newHalf = 4;
+        }
+      } else {
+        if (period <= 2) {
+          newPhase = 'regular';
+          minutes = preset.halfDuration;
+          seconds = 0;
+          newHalf = period;
+        } else if (preset.hasPenalties) {
+          newHalf = 5;
+          newPhase = 'penalties';
+          minutes = 0;
+          seconds = 0;
+        } else {
+          newHalf = 2;
+        }
+      }
+
+      return {
+        ...prev,
+        half: newHalf,
+        matchPhase: newPhase,
+        time: { minutes, seconds },
+        isRunning: false,
+      };
+    });
   }, []);
 
   const changeGamePreset = useCallback((presetIndex: number) => {


### PR DESCRIPTION
## Summary
- Prevent adding extra time for regular football matches and direct-to-penalties format
- Enable auto-configured 15-minute halves for extra time in knockout matches
- Show current phase label (e.g., Penalty Shootout) and disable advancing beyond allowed periods

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890ef820884832db646222ff9d64910