### PR TITLE
feat: add stats toggle to overlay

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ function App() {
     <div className="App">
       {viewMode === 'overlay' ? (
         <div className="relative min-h-screen bg-transparent">
-          <Overlay gameState={gameState.gameState} />
+          <Overlay gameState={gameState.gameState} showStats />
           {/* Floating control button */}
           <ControlPanelButton onClick={() => setViewMode('dashboard')} />
         </div>

--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -4,9 +4,10 @@ import { Crown } from 'lucide-react';
 
 interface OverlayProps {
   gameState: GameState;
+  showStats?: boolean;
 }
 
-export const Overlay: React.FC<OverlayProps> = ({ gameState }) => {
+export const Overlay: React.FC<OverlayProps> = ({ gameState, showStats = true }) => {
   const { homeTeam, awayTeam, time } = gameState;
   
   const formatTime = (minutes: number, seconds: number) => {
@@ -77,29 +78,31 @@ export const Overlay: React.FC<OverlayProps> = ({ gameState }) => {
       </div>
 
       {/* Bottom Stats Bar (Optional - can be toggled) */}
+      {showStats && (
         <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 z-50">
           <div className="bg-black/60 backdrop-blur-md rounded-xl border border-white/10 px-6 py-2">
             <div className="flex items-center gap-8 text-sm">
               <div className="flex items-center gap-2">
                 <span className="text-blue-400 font-medium">{homeTeam.name}</span>
-              <span className="text-white/60">Fouls:</span>
-              <span className="text-red-400 font-bold">{homeTeam.fouls}</span>
-              <span className="text-white/60">|</span>
-              <span className="text-white/60">Poss:</span>
-              <span className="text-blue-400 font-bold">{homeTeam.stats.possession}%</span>
-            </div>
-            <div className="w-px h-4 bg-white/20"></div>
-            <div className="flex items-center gap-2">
-              <span className="text-red-400 font-medium">{awayTeam.name}</span>
-              <span className="text-white/60">Fouls:</span>
-              <span className="text-red-400 font-bold">{awayTeam.fouls}</span>
-              <span className="text-white/60">|</span>
-              <span className="text-white/60">Poss:</span>
-              <span className="text-red-400 font-bold">{awayTeam.stats.possession}%</span>
+                <span className="text-white/60">Fouls:</span>
+                <span className="text-red-400 font-bold">{homeTeam.fouls}</span>
+                <span className="text-white/60">|</span>
+                <span className="text-white/60">Poss:</span>
+                <span className="text-blue-400 font-bold">{homeTeam.stats.possession}%</span>
+              </div>
+              <div className="w-px h-4 bg-white/20"></div>
+              <div className="flex items-center gap-2">
+                <span className="text-red-400 font-medium">{awayTeam.name}</span>
+                <span className="text-white/60">Fouls:</span>
+                <span className="text-red-400 font-bold">{awayTeam.fouls}</span>
+                <span className="text-white/60">|</span>
+                <span className="text-white/60">Poss:</span>
+                <span className="text-red-400 font-bold">{awayTeam.stats.possession}%</span>
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add optional `showStats` prop to `Overlay`
- conditionally render stats bar
- update app to configure stats bar display

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890f16a9de8832d9fa6c16c2b048af2