### PR TITLE
Handle missing game state in overlay

### DIFF
--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -3,10 +3,12 @@ import { GameState } from '../types';
 import { Crown } from 'lucide-react';
 
 interface OverlayProps {
-  gameState: GameState;
+  gameState?: GameState | null;
 }
 
 export const Overlay: React.FC<OverlayProps> = ({ gameState }) => {
+  if (!gameState) return null;
+
   const { homeTeam, awayTeam, time } = gameState;
   
   const formatTime = (minutes: number, seconds: number) => {


### PR DESCRIPTION
## Summary
- Return null from overlay when game state is unavailable
- Delay state destructuring until after null check to avoid runtime errors

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890f16d8940832d9bd3a17638142fea