### PR TITLE
feat: add format utilities

### DIFF
--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { GameState } from '../types';
 import { Crown } from 'lucide-react';
+import { formatTime, isWinning } from '../utils/format';
 
 interface OverlayProps {
   gameState: GameState;
@@ -8,15 +9,6 @@ interface OverlayProps {
 
 export const Overlay: React.FC<OverlayProps> = ({ gameState }) => {
   const { homeTeam, awayTeam, time } = gameState;
-  
-  const formatTime = (minutes: number, seconds: number) => {
-    return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
-  };
-
-  const isWinning = (teamScore: number, opponentScore: number) => {
-    return teamScore > opponentScore;
-  };
-
 
   return (
     <div className="fixed inset-0 pointer-events-none">

--- a/src/components/Scoreboard.tsx
+++ b/src/components/Scoreboard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { GameState } from '../types';
 import { getHalfName } from '../utils/gamePresets';
 import { Crown } from 'lucide-react';
+import { formatTime, isWinning } from '../utils/format';
 
 interface ScoreboardProps {
   gameState: GameState;
@@ -9,14 +10,6 @@ interface ScoreboardProps {
 
 export const Scoreboard: React.FC<ScoreboardProps> = ({ gameState }) => {
   const { homeTeam, awayTeam, time } = gameState;
-  
-  const formatTime = (minutes: number, seconds: number) => {
-    return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
-  };
-
-  const isWinning = (score1: number, score2: number) => {
-    return score1 > score2;
-  };
 
   return (
     <div className="w-screen h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 text-white flex items-center justify-center overflow-hidden">

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,7 @@
+export const formatTime = (minutes: number, seconds: number): string => {
+  return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+};
+
+export const isWinning = (teamScore: number, opponentScore: number): boolean => {
+  return teamScore > opponentScore;
+};


### PR DESCRIPTION
## Summary
- add common `formatTime` and `isWinning` utilities
- use shared utilities in `Overlay` and `Scoreboard`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890f16ddb54832d844f5a4d3aadee7f