### PR TITLE
Handle absent game state in overlay component

### DIFF
--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -4,11 +4,13 @@ import { Crown } from 'lucide-react';
 import { formatTime, isWinning } from '../utils/format';
 
 interface OverlayProps {
-  gameState: GameState;
+  gameState?: GameState | null;
   showStats?: boolean;
 }
 
 export const Overlay: React.FC<OverlayProps> = ({ gameState, showStats = true }) => {
+  if (!gameState) return null;
+
   const { homeTeam, awayTeam, time } = gameState;
 
   return (


### PR DESCRIPTION
## Summary
- Allow Overlay to accept `gameState` as optional
- Guard rendering when no game state is provided

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890f31252f4832db4903f1c4b5ac235