### PR TITLE
Remove offsides stat for futsal presets

### DIFF
--- a/src/components/StatsTracker.tsx
+++ b/src/components/StatsTracker.tsx
@@ -199,8 +199,8 @@ export const StatsTracker: React.FC<StatsTrackerProps> = ({
               label="Offsides"
               icon={Flag}
               stat="offsides"
-              homeValue={homeTeam.stats.offsides}
-              awayValue={awayTeam.stats.offsides}
+              homeValue={homeTeam.stats.offsides ?? 0}
+              awayValue={awayTeam.stats.offsides ?? 0}
             />
           )}
 

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -2,6 +2,24 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import { GameState, Team } from '../types';
 import { GAME_PRESETS, shouldAutoAdvance } from '../utils/gamePresets';
 
+const adjustTeamStatsForType = (team: Team, type: GameState['gamePreset']['type']): Team => {
+  if (type === 'football') {
+    return {
+      ...team,
+      stats: {
+        ...team.stats,
+        offsides: team.stats.offsides ?? 0,
+      },
+    };
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { offsides: _unused, ...rest } = team.stats;
+  return {
+    ...team,
+    stats: rest,
+  };
+};
+
 const initialState: GameState = {
   homeTeam: {
     name: 'Home Team',
@@ -11,7 +29,6 @@ const initialState: GameState = {
       shots: 0,
       shotsOnTarget: 0,
       corners: 0,
-      offsides: 0,
       yellowCards: 0,
       redCards: 0,
       possession: 50,
@@ -25,7 +42,6 @@ const initialState: GameState = {
       shots: 0,
       shotsOnTarget: 0,
       corners: 0,
-      offsides: 0,
       yellowCards: 0,
       redCards: 0,
       possession: 50,
@@ -214,15 +230,25 @@ export const useGameState = () => {
       half: 1,
       matchPhase: 'regular',
       isRunning: false,
+      homeTeam: adjustTeamStatsForType(prev.homeTeam, preset.type),
+      awayTeam: adjustTeamStatsForType(prev.awayTeam, preset.type),
     }));
   }, []);
   const resetGame = useCallback(() => {
-    setGameState(prev => ({
-      ...initialState,
-      gamePreset: prev.gamePreset, // Keep current preset
-      time: { minutes: prev.gamePreset.halfDuration, seconds: 0 },
-      possessionStartTime: Date.now(),
-    }));
+    setGameState(prev => {
+      const base = {
+        ...initialState,
+        gamePreset: prev.gamePreset, // Keep current preset
+        time: { minutes: prev.gamePreset.halfDuration, seconds: 0 },
+        possessionStartTime: Date.now(),
+      };
+
+      return {
+        ...base,
+        homeTeam: adjustTeamStatsForType(base.homeTeam, prev.gamePreset.type),
+        awayTeam: adjustTeamStatsForType(base.awayTeam, prev.gamePreset.type),
+      };
+    });
   }, []);
 
   // Keyboard shortcuts for external control

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,7 +7,7 @@ export interface Team {
     shots: number;
     shotsOnTarget: number;
     corners: number;
-    offsides: number;
+    offsides?: number;
     yellowCards: number;
     redCards: number;
     possession: number; // percentage


### PR DESCRIPTION
## Summary
- Hide offsides tracking when futsal is selected by making the stat optional
- Update state transitions to add or strip the offsides field depending on game type
- Ensure stats tracker only renders offsides for football and handles missing values

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890f2168cf0832d9454aacf7c31652a