### PR TITLE
Validate timer control messages

### DIFF
--- a/src/hooks/useGameState.test.ts
+++ b/src/hooks/useGameState.test.ts
@@ -1,0 +1,28 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { useGameState } from './useGameState';
+
+describe('useGameState message handling', () => {
+  it('ignores invalid messages without throwing', () => {
+    const { result, unmount } = renderHook(() => useGameState());
+
+    const invalidMessages = [
+      'string',
+      { foo: 'bar' },
+      { type: 'UNKNOWN', action: 'START' },
+      { type: 'TIMER_CONTROL', action: 'UNKNOWN' },
+    ];
+
+    invalidMessages.forEach(data => {
+      expect(() => {
+        window.dispatchEvent(
+          new MessageEvent('message', { data, origin: window.location.origin })
+        );
+      }).not.toThrow();
+      expect(result.current.gameState.isRunning).toBe(false);
+    });
+
+    unmount();
+  });
+});
+

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -301,23 +301,37 @@ export const useGameState = () => {
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
       if (event.origin !== window.location.origin) return;
-      
-      const { type, action } = event.data;
-      if (type === 'TIMER_CONTROL') {
-        switch (action) {
-          case 'START':
-            setGameState(prev => ({ ...prev, isRunning: true }));
-            break;
-          case 'STOP':
-            setGameState(prev => ({ ...prev, isRunning: false }));
-            break;
-          case 'TOGGLE':
-            toggleTimer();
-            break;
-          case 'RESET':
-            resetTimer();
-            break;
-        }
+
+      if (typeof event.data !== 'object' || event.data === null) {
+        return;
+      }
+
+      if (!('type' in event.data) || !('action' in event.data)) {
+        return;
+      }
+
+      const { type, action } = event.data as { type: unknown; action: unknown };
+
+      if (type !== 'TIMER_CONTROL' || typeof action !== 'string') {
+        return;
+      }
+
+      switch (action) {
+        case 'START':
+          setGameState(prev => ({ ...prev, isRunning: true }));
+          break;
+        case 'STOP':
+          setGameState(prev => ({ ...prev, isRunning: false }));
+          break;
+        case 'TOGGLE':
+          toggleTimer();
+          break;
+        case 'RESET':
+          resetTimer();
+          break;
+        default:
+          // Ignore unknown actions
+          break;
       }
     };
 


### PR DESCRIPTION
## Summary
- harden message handling by verifying structure before using timer-control events
- ignore unknown timer actions via default case
- add tests covering malformed or unexpected messages

## Testing
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: TS6133, TS2339, TS18048, TS2307, TS6133)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890f709ccb0832d806bb39d43b43a84