### PR TITLE
feat: add custom design tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
-futsal
+# Futsal Scoreboard
+
+This project provides a web-based scoreboard and control dashboard for futsal matches. It is built with React, Vite, and Tailwind CSS.
+
+## Design Tokens
+
+Custom design tokens are defined in `tailwind.config.js` and exposed through Tailwind utility classes.
+
+### Colors
+
+- `brand` (`brand-50` … `brand-900`): primary blue palette used throughout controls and backgrounds.
+- `accent` (`accent-50` … `accent-900`): secondary red palette for emphasis and opponent styling.
+
+### Fonts
+
+- `font-sans`: Inter, used for general text.
+- `font-display`: Orbitron, used for headings and scores.
+
+### Spacing
+
+- `18` (`p-18`, `gap-18`, etc.): 4.5rem spacing step for generous layout
+- `128` (`w-128`, `h-128`, etc.): 32rem large dimension utility
+
+Use these tokens with standard Tailwind class syntax, e.g. `bg-brand-500`, `font-display`, or `p-18`.
+
+## Development
+
+Install dependencies and run the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+Lint the project:
+
+```bash
+npm run lint
+```

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -99,23 +99,23 @@ export const Dashboard: React.FC<DashboardProps> = ({
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 text-gray-900">
+    <div className="min-h-screen bg-brand-50 text-brand-900 font-sans p-18">
       {/* Header */}
-      <div className="bg-white shadow-sm border-b border-gray-200">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div className="bg-white shadow-sm border-b border-brand-200">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-18">
           <div className="flex justify-between items-center py-4">
-            <h1 className="text-2xl font-bold text-gray-900">Futsal Scoreboard Control</h1>
-            <div className="flex gap-3">
+            <h1 className="text-2xl font-display text-brand-900">Futsal Scoreboard Control</h1>
+            <div className="flex gap-6">
               <button
                 onClick={() => onViewChange('scoreboard')}
-                className="inline-flex items-center gap-2 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors"
+                className="inline-flex items-center gap-2 px-4 py-2 bg-brand-600 text-white rounded-lg hover:bg-brand-700 transition-colors"
               >
                 <Monitor className="w-4 h-4" />
                 View Scoreboard
               </button>
               <button
                 onClick={() => onViewChange('overlay')}
-                className="inline-flex items-center gap-2 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors"
+                className="inline-flex items-center gap-2 px-4 py-2 bg-accent-600 text-white rounded-lg hover:bg-accent-700 transition-colors"
               >
                 <Monitor className="w-4 h-4" />
                 Streaming Overlay

--- a/src/components/Scoreboard.tsx
+++ b/src/components/Scoreboard.tsx
@@ -12,10 +12,10 @@ export const Scoreboard: React.FC<ScoreboardProps> = ({ gameState }) => {
   const { homeTeam, awayTeam, time } = gameState;
 
   return (
-    <div className="w-screen h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 text-white flex items-center justify-center overflow-hidden">
+    <div className="w-screen h-screen bg-gradient-to-br from-brand-900 via-brand-800 to-brand-900 text-white flex items-center justify-center overflow-hidden font-sans">
       <div className="w-full h-full flex items-center justify-center px-8 py-6">
         {/* Main Scoreboard */}
-        <div className="bg-black/40 backdrop-blur-lg rounded-3xl border border-gray-700/50 shadow-2xl w-full max-w-7xl h-full max-h-[900px] flex flex-col justify-center p-12">
+        <div className="bg-black/40 backdrop-blur-lg rounded-3xl border border-gray-700/50 shadow-2xl w-full max-w-7xl h-full max-h-[900px] flex flex-col justify-center p-18">
           {/* Header */}
           {gameState.tournamentLogo && (
             <div className="text-center mb-12">
@@ -30,7 +30,7 @@ export const Scoreboard: React.FC<ScoreboardProps> = ({ gameState }) => {
           )}
 
           {/* Teams and Score */}
-          <div className={`grid grid-cols-3 gap-16 items-center flex-1 ${!gameState.tournamentLogo ? 'justify-center' : ''}`}>
+          <div className={`grid grid-cols-3 gap-18 items-center flex-1 ${!gameState.tournamentLogo ? 'justify-center' : ''}`}>
             {/* Home Team */}
             <div className="text-center space-y-6">
               <div className="relative">
@@ -41,21 +41,21 @@ export const Scoreboard: React.FC<ScoreboardProps> = ({ gameState }) => {
                     className="w-32 h-32 object-cover rounded-full mx-auto border-4 border-gray-600"
                   />
                 ) : (
-                  <div className="w-32 h-32 bg-gradient-to-br from-blue-500 to-blue-700 rounded-full mx-auto flex items-center justify-center border-4 border-gray-600">
-                    <span className="text-4xl font-bold">{homeTeam.name.charAt(0)}</span>
+                  <div className="w-32 h-32 bg-gradient-to-br from-brand-500 to-brand-700 rounded-full mx-auto flex items-center justify-center border-4 border-gray-600">
+                    <span className="text-4xl font-display">{homeTeam.name.charAt(0)}</span>
                   </div>
                 )}
                 {isWinning(homeTeam.score, awayTeam.score) && (
                   <Crown className="w-8 h-8 text-yellow-400 absolute -top-3 -right-3" />
                 )}
               </div>
-              <h2 className="text-3xl font-bold text-blue-400 truncate">{homeTeam.name}</h2>
-              <div className="bg-blue-500/20 rounded-xl p-6">
-                <div className="text-8xl font-bold text-blue-400">{homeTeam.score}</div>
+              <h2 className="text-3xl font-display text-brand-400 truncate">{homeTeam.name}</h2>
+              <div className="bg-brand-500/20 rounded-xl p-6">
+                <div className="text-8xl font-display text-brand-400">{homeTeam.score}</div>
               </div>
               <div className="flex items-center justify-center gap-3">
                 <span className="text-lg text-gray-400">Fouls:</span>
-                <span className="bg-red-500/20 text-red-400 px-4 py-2 rounded-full text-xl font-semibold">
+                <span className="bg-accent-500/20 text-accent-400 px-4 py-2 rounded-full text-xl font-semibold">
                   {homeTeam.fouls}
                 </span>
               </div>
@@ -63,9 +63,9 @@ export const Scoreboard: React.FC<ScoreboardProps> = ({ gameState }) => {
 
             {/* Center - Time and Period */}
             <div className="text-center space-y-8">
-              <div className="bg-gradient-to-r from-green-500/20 to-emerald-500/20 rounded-2xl p-8 border border-green-500/30">
-                <div className="text-lg text-green-400 mb-3">TIME</div>
-                <div className="text-7xl font-mono font-bold text-green-400 mb-4">
+              <div className="bg-gradient-to-r from-brand-500/20 to-accent-500/20 rounded-2xl p-8 border border-brand-500/30">
+                <div className="text-lg text-brand-400 mb-3">TIME</div>
+                <div className="text-7xl font-mono font-bold text-brand-400 mb-4">
                   {formatTime(time.minutes, time.seconds)}
                 </div>
                 <div className="text-lg text-gray-400">
@@ -92,27 +92,27 @@ export const Scoreboard: React.FC<ScoreboardProps> = ({ gameState }) => {
             <div className="text-center space-y-6">
               <div className="relative">
                 {awayTeam.logo ? (
-                  <img 
-                    src={awayTeam.logo} 
+                  <img
+                    src={awayTeam.logo}
                     alt={awayTeam.name}
                     className="w-32 h-32 object-cover rounded-full mx-auto border-4 border-gray-600"
                   />
                 ) : (
-                  <div className="w-32 h-32 bg-gradient-to-br from-red-500 to-red-700 rounded-full mx-auto flex items-center justify-center border-4 border-gray-600">
-                    <span className="text-4xl font-bold">{awayTeam.name.charAt(0)}</span>
+                  <div className="w-32 h-32 bg-gradient-to-br from-accent-500 to-accent-700 rounded-full mx-auto flex items-center justify-center border-4 border-gray-600">
+                    <span className="text-4xl font-display">{awayTeam.name.charAt(0)}</span>
                   </div>
                 )}
                 {isWinning(awayTeam.score, homeTeam.score) && (
                   <Crown className="w-8 h-8 text-yellow-400 absolute -top-3 -right-3" />
                 )}
               </div>
-              <h2 className="text-3xl font-bold text-red-400 truncate">{awayTeam.name}</h2>
-              <div className="bg-red-500/20 rounded-xl p-6">
-                <div className="text-8xl font-bold text-red-400">{awayTeam.score}</div>
+              <h2 className="text-3xl font-display text-accent-400 truncate">{awayTeam.name}</h2>
+              <div className="bg-accent-500/20 rounded-xl p-6">
+                <div className="text-8xl font-display text-accent-400">{awayTeam.score}</div>
               </div>
               <div className="flex items-center justify-center gap-3">
                 <span className="text-lg text-gray-400">Fouls:</span>
-                <span className="bg-red-500/20 text-red-400 px-4 py-2 rounded-full text-xl font-semibold">
+                <span className="bg-accent-500/20 text-accent-400 px-4 py-2 rounded-full text-xl font-semibold">
                   {awayTeam.fouls}
                 </span>
               </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Orbitron:wght@600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,42 @@
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        brand: {
+          50: '#f0f5ff',
+          100: '#d6e4ff',
+          200: '#adc8ff',
+          300: '#85a9ff',
+          400: '#5e87ff',
+          500: '#3f63ff',
+          600: '#3352db',
+          700: '#263ca8',
+          800: '#1a2775',
+          900: '#0e1342',
+        },
+        accent: {
+          50: '#fff5f5',
+          100: '#ffe3e3',
+          200: '#ffc9c9',
+          300: '#ffa8a8',
+          400: '#ff8787',
+          500: '#ff6b6b',
+          600: '#fa5252',
+          700: '#f03e3e',
+          800: '#e03131',
+          900: '#c92a2a',
+        },
+      },
+      fontFamily: {
+        sans: ['Inter', 'sans-serif'],
+        display: ['Orbitron', 'sans-serif'],
+      },
+      spacing: {
+        18: '4.5rem',
+        128: '32rem',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- expand Tailwind theme with branded colors, fonts, and spacing tokens
- style dashboard and scoreboard with new design tokens
- document available design tokens and usage

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6890f72c07c0832d96e8b3b657436682