### PR TITLE
feat: add light and dark mode toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,20 @@
 import React, { useState } from 'react';
 import { useGameState } from './hooks/useGameState';
+import { useTheme } from './hooks/useTheme';
 import { Scoreboard } from './components/Scoreboard';
 import { Dashboard } from './components/Dashboard';
 import { Overlay } from './components/Overlay';
 import { StatsTracker } from './components/StatsTracker';
 import { PossessionTracker } from './components/PossessionTracker';
 import { ControlPanelButton } from './components/ControlPanelButton';
+import { ThemeToggle } from './components/ThemeToggle';
 
 type ViewMode = 'scoreboard' | 'dashboard' | 'overlay' | 'stats' | 'possession';
 
 function App() {
   const [viewMode, setViewMode] = useState<ViewMode>('dashboard');
   const gameState = useGameState();
+  const { theme, toggleTheme } = useTheme();
 
   const handleViewChange = (view: ViewMode) => {
     setViewMode(view);
@@ -19,6 +22,7 @@ function App() {
 
   return (
     <div className="App">
+      <ThemeToggle theme={theme} onToggle={toggleTheme} />
       {viewMode === 'overlay' ? (
         <div className="relative min-h-screen bg-transparent">
           <Overlay gameState={gameState.gameState} showStats />

--- a/src/components/ControlPanelButton.tsx
+++ b/src/components/ControlPanelButton.tsx
@@ -10,7 +10,7 @@ export const ControlPanelButton: React.FC<ControlPanelButtonProps> = ({ onClick 
   <button
     onClick={onClick}
     aria-label="Open control panel"
-    className="fixed top-5 right-5 w-12 h-12 rounded-full bg-indigo-600/80 text-white flex items-center justify-center shadow-lg hover:bg-indigo-600 backdrop-blur-md transition-colors z-50"
+    className="fixed top-5 right-20 w-12 h-12 rounded-full bg-indigo-600/80 text-white flex items-center justify-center shadow-lg hover:bg-indigo-600 backdrop-blur-md transition-colors z-50"
   >
     <Settings className="w-5 h-5" />
   </button>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -119,12 +119,12 @@ export const Dashboard: React.FC<DashboardProps> = ({
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 text-gray-900">
+    <div className="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
       {/* Header */}
-      <div className="bg-white shadow-sm border-b border-gray-200">
+      <div className="bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-4">
-            <h1 className="text-2xl font-bold text-gray-900">Futsal Scoreboard Control</h1>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Futsal Scoreboard Control</h1>
             <div className="flex gap-3">
               <button
                 onClick={() => onViewChange('scoreboard')}
@@ -271,7 +271,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
             </div>
 
             {/* Home Team */}
-            <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+            <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
               <h3 className="text-lg font-semibold text-blue-600 mb-6">Home Team</h3>
               
               <div className="space-y-6">
@@ -356,7 +356,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
             </div>
 
             {/* Away Team */}
-            <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+            <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
               <h3 className="text-lg font-semibold text-red-600 mb-6">Away Team</h3>
               
               <div className="space-y-6">
@@ -444,8 +444,8 @@ export const Dashboard: React.FC<DashboardProps> = ({
 
         {/* Timer Tab */}
         {activeTab === 'timer' && (
-          <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-8 max-w-2xl mx-auto">
-            <h3 className="text-lg font-semibold text-gray-900 mb-8 text-center">Timer Control</h3>
+          <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-8 max-w-2xl mx-auto">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-8 text-center">Timer Control</h3>
             
             <div className="space-y-8">
               {/* Timer Display */}
@@ -504,7 +504,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
                     >
                       <Minus className="w-4 h-4" />
                     </button>
-                    <span className="text-2xl font-bold text-gray-900 min-w-[3rem] text-center">
+                    <span className="text-2xl font-bold text-gray-900 dark:text-gray-100 min-w-[3rem] text-center">
                       {gameState.time.minutes}
                     </span>
                     <button
@@ -525,7 +525,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
                     >
                       <Minus className="w-4 h-4" />
                     </button>
-                    <span className="text-2xl font-bold text-gray-900 min-w-[3rem] text-center">
+                    <span className="text-2xl font-bold text-gray-900 dark:text-gray-100 min-w-[3rem] text-center">
                       {gameState.time.seconds}
                     </span>
                     <button
@@ -573,7 +573,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
                         >
                           <Minus className="w-4 h-4" />
                         </button>
-                        <span className="text-xl font-bold text-gray-900 min-w-[3rem] text-center">
+                        <span className="text-xl font-bold text-gray-900 dark:text-gray-100 min-w-[3rem] text-center">
                           {gameState.half}
                         </span>
                         <button
@@ -609,8 +609,8 @@ export const Dashboard: React.FC<DashboardProps> = ({
 
         {/* Settings Tab */}
         {activeTab === 'settings' && (
-          <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-8 max-w-2xl mx-auto">
-            <h3 className="text-lg font-semibold text-gray-900 mb-8 text-center">Game Settings</h3>
+          <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-8 max-w-2xl mx-auto">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-8 text-center">Game Settings</h3>
             
             <div className="space-y-8">
               {/* External Control Info */}
@@ -630,7 +630,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
               </div>
 
               <div className="border-t pt-6">
-                <h4 className="font-semibold text-gray-900 mb-4">Quick Actions</h4>
+                <h4 className="font-semibold text-gray-900 dark:text-gray-100 mb-4">Quick Actions</h4>
                 <div className="grid grid-cols-2 gap-4">
                   <button
                     onClick={() => {

--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -25,7 +25,7 @@ export const Overlay: React.FC<OverlayProps> = ({ gameState, showStats = true })
         exit={{ y: shouldReduceMotion ? 0 : -50, opacity: 0 }}
         transition={{ duration: shouldReduceMotion ? 0 : 0.3 }}
       >
-        <div className="flex h-full text-white shadow-2xl">
+        <div className="flex h-full text-gray-900 dark:text-white shadow-2xl">
           {/* Home Team */}
           <div className="flex items-center gap-2 px-4 h-full bg-blue-600/80 backdrop-blur-md">
             <div className="relative">
@@ -90,24 +90,24 @@ export const Overlay: React.FC<OverlayProps> = ({ gameState, showStats = true })
             exit={{ y: shouldReduceMotion ? 0 : 50, opacity: 0 }}
             transition={{ duration: shouldReduceMotion ? 0 : 0.3 }}
           >
-            <div className="bg-black/60 backdrop-blur-md rounded-xl border border-white/10 px-6 py-2">
+            <div className="bg-white/70 dark:bg-black/60 backdrop-blur-md rounded-xl border border-gray-200 dark:border-white/10 px-6 py-2">
               <div className="flex items-center gap-8 text-sm">
                 <div className="flex items-center gap-2">
-                  <span className="text-blue-400 font-medium">{homeTeam.name}</span>
-                  <span className="text-white/60">Fouls:</span>
-                  <span className="text-red-400 font-bold">{homeTeam.fouls}</span>
-                  <span className="text-white/60">|</span>
-                  <span className="text-white/60">Poss:</span>
-                  <span className="text-blue-400 font-bold">{homeTeam.stats.possession}%</span>
+                  <span className="text-blue-600 dark:text-blue-400 font-medium">{homeTeam.name}</span>
+                  <span className="text-gray-600 dark:text-white/60">Fouls:</span>
+                  <span className="text-red-600 dark:text-red-400 font-bold">{homeTeam.fouls}</span>
+                  <span className="text-gray-600 dark:text-white/60">|</span>
+                  <span className="text-gray-600 dark:text-white/60">Poss:</span>
+                  <span className="text-blue-600 dark:text-blue-400 font-bold">{homeTeam.stats.possession}%</span>
                 </div>
-                <div className="w-px h-4 bg-white/20"></div>
+                <div className="w-px h-4 bg-gray-300 dark:bg-white/20"></div>
                 <div className="flex items-center gap-2">
-                  <span className="text-red-400 font-medium">{awayTeam.name}</span>
-                  <span className="text-white/60">Fouls:</span>
-                  <span className="text-red-400 font-bold">{awayTeam.fouls}</span>
-                  <span className="text-white/60">|</span>
-                  <span className="text-white/60">Poss:</span>
-                  <span className="text-red-400 font-bold">{awayTeam.stats.possession}%</span>
+                  <span className="text-red-600 dark:text-red-400 font-medium">{awayTeam.name}</span>
+                  <span className="text-gray-600 dark:text-white/60">Fouls:</span>
+                  <span className="text-red-600 dark:text-red-400 font-bold">{awayTeam.fouls}</span>
+                  <span className="text-gray-600 dark:text-white/60">|</span>
+                  <span className="text-gray-600 dark:text-white/60">Poss:</span>
+                  <span className="text-red-600 dark:text-red-400 font-bold">{awayTeam.stats.possession}%</span>
                 </div>
               </div>
             </div>

--- a/src/components/PossessionTracker.tsx
+++ b/src/components/PossessionTracker.tsx
@@ -14,16 +14,16 @@ export const PossessionTracker: React.FC<PossessionTrackerProps> = ({
   const { homeTeam, awayTeam, ballPossession, isRunning } = gameState;
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-green-50 to-blue-50 text-gray-900">
+    <div className="min-h-screen bg-gradient-to-br from-green-50 to-blue-50 text-gray-900 dark:from-green-900 dark:to-blue-900 dark:text-gray-100">
       {/* Header */}
-      <div className="bg-white shadow-sm border-b border-gray-200">
+      <div className="bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-4">
-            <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 flex items-center gap-2">
               <Timer className="w-6 h-6 text-green-600" />
               Ball Possession Control
             </h1>
-            <div className="text-sm text-gray-600">
+            <div className="text-sm text-gray-600 dark:text-gray-400">
               Dedicated Possession Operator Interface
             </div>
           </div>
@@ -32,10 +32,10 @@ export const PossessionTracker: React.FC<PossessionTrackerProps> = ({
 
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Game Status */}
-        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 mb-8">
+        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6 mb-8">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4">
-              <h3 className="text-lg font-semibold text-gray-900">Match Status</h3>
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Match Status</h3>
               <div className={`inline-flex items-center gap-2 px-3 py-1 rounded-full ${
                 isRunning 
                   ? 'bg-green-100 text-green-700' 
@@ -48,7 +48,7 @@ export const PossessionTracker: React.FC<PossessionTrackerProps> = ({
               </div>
             </div>
             <div className="text-right">
-              <div className="text-sm text-gray-600">Current Score</div>
+              <div className="text-sm text-gray-600 dark:text-gray-400">Current Score</div>
               <div className="text-xl font-bold">
                 <span className="text-blue-600">{homeTeam.name} {homeTeam.score}</span>
                 <span className="text-gray-400 mx-2">-</span>
@@ -59,8 +59,8 @@ export const PossessionTracker: React.FC<PossessionTrackerProps> = ({
         </div>
 
         {/* Main Possession Control */}
-        <div className="bg-white rounded-xl shadow-lg border border-gray-200 p-8 mb-8">
-          <h3 className="text-xl font-semibold text-gray-900 mb-6 text-center flex items-center justify-center gap-2">
+        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-200 dark:border-gray-700 p-8 mb-8">
+          <h3 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-6 text-center flex items-center justify-center gap-2">
             <Users className="w-6 h-6 text-green-600" />
             Ball Possession Control
           </h3>
@@ -72,7 +72,7 @@ export const PossessionTracker: React.FC<PossessionTrackerProps> = ({
               className={`p-8 rounded-xl border-4 transition-all transform hover:scale-105 ${
                 ballPossession === 'home'
                   ? 'border-blue-500 bg-blue-50 text-blue-700 shadow-lg'
-                  : 'border-gray-200 bg-white text-gray-600 hover:border-blue-300 hover:shadow-md'
+                  : 'border-gray-200 bg-white text-gray-600 hover:border-blue-300 hover:shadow-md dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-blue-500'
               }`}
             >
               <div className="text-center">
@@ -102,7 +102,7 @@ export const PossessionTracker: React.FC<PossessionTrackerProps> = ({
 
             {/* Center Status */}
             <div className="text-center">
-              <div className="text-sm text-gray-600 mb-3">Current Ball Possession</div>
+              <div className="text-sm text-gray-600 dark:text-gray-400 mb-3">Current Ball Possession</div>
               <div className={`inline-flex items-center gap-3 px-6 py-4 rounded-full font-bold text-lg ${
                 ballPossession === 'home' 
                   ? 'bg-blue-100 text-blue-700 border-2 border-blue-300' 
@@ -114,7 +114,7 @@ export const PossessionTracker: React.FC<PossessionTrackerProps> = ({
                 {ballPossession === 'home' ? homeTeam.name : awayTeam.name}
               </div>
               
-              <div className="mt-4 text-xs text-gray-500">
+              <div className="mt-4 text-xs text-gray-500 dark:text-gray-400">
                 Click team buttons to switch possession (only when timer is running)
               </div>
             </div>
@@ -125,7 +125,7 @@ export const PossessionTracker: React.FC<PossessionTrackerProps> = ({
               className={`p-8 rounded-xl border-4 transition-all transform hover:scale-105 ${
                 ballPossession === 'away'
                   ? 'border-red-500 bg-red-50 text-red-700 shadow-lg'
-                  : 'border-gray-200 bg-white text-gray-600 hover:border-red-300 hover:shadow-md'
+                  : 'border-gray-200 bg-white text-gray-600 hover:border-red-300 hover:shadow-md dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-red-500'
               }`}
             >
               <div className="text-center">
@@ -156,19 +156,19 @@ export const PossessionTracker: React.FC<PossessionTrackerProps> = ({
         </div>
 
         {/* Quick Stats Summary */}
-        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
-          <h4 className="font-semibold text-gray-900 mb-4">Possession Summary</h4>
+        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+          <h4 className="font-semibold text-gray-900 dark:text-gray-100 mb-4">Possession Summary</h4>
           
           <div className="grid grid-cols-2 gap-6">
             <div className="text-center">
-              <div className="text-sm text-gray-600 mb-1">{homeTeam.name}</div>
+            <div className="text-sm text-gray-600 dark:text-gray-400 mb-1">{homeTeam.name}</div>
               <div className="flex items-center justify-center gap-2">
                 <div className="w-4 h-4 bg-blue-500 rounded"></div>
                 <span className="text-xl font-bold text-blue-600">{homeTeam.stats.possession}%</span>
               </div>
             </div>
             <div className="text-center">
-              <div className="text-sm text-gray-600 mb-1">{awayTeam.name}</div>
+            <div className="text-sm text-gray-600 dark:text-gray-400 mb-1">{awayTeam.name}</div>
               <div className="flex items-center justify-center gap-2">
                 <div className="w-4 h-4 bg-red-500 rounded"></div>
                 <span className="text-xl font-bold text-red-600">{awayTeam.stats.possession}%</span>
@@ -176,8 +176,8 @@ export const PossessionTracker: React.FC<PossessionTrackerProps> = ({
             </div>
           </div>
 
-          <div className="mt-4 bg-gray-100 rounded-lg h-4 overflow-hidden">
-            <div 
+          <div className="mt-4 bg-gray-100 dark:bg-gray-700 rounded-lg h-4 overflow-hidden">
+            <div
               className="h-full bg-gradient-to-r from-blue-500 to-blue-600 transition-all duration-500"
               style={{ width: `${homeTeam.stats.possession}%` }}
             ></div>
@@ -185,9 +185,9 @@ export const PossessionTracker: React.FC<PossessionTrackerProps> = ({
         </div>
 
         {/* Instructions */}
-        <div className="mt-8 bg-green-50 rounded-xl border border-green-200 p-6">
-          <h4 className="font-semibold text-green-900 mb-3">Operator Instructions</h4>
-          <ul className="space-y-2 text-sm text-green-800">
+        <div className="mt-8 bg-green-50 dark:bg-green-900 rounded-xl border border-green-200 dark:border-green-700 p-6">
+          <h4 className="font-semibold text-green-900 dark:text-green-100 mb-3">Operator Instructions</h4>
+          <ul className="space-y-2 text-sm text-green-800 dark:text-green-200">
             <li>• <strong>Click team buttons</strong> to switch ball possession when play changes</li>
             <li>• <strong>Keyboard shortcuts</strong>: Press <kbd className="bg-green-100 px-2 py-1 rounded text-xs">A</kbd> or <kbd className="bg-green-100 px-2 py-1 rounded text-xs">1</kbd> for Home team, <kbd className="bg-green-100 px-2 py-1 rounded text-xs">D</kbd> or <kbd className="bg-green-100 px-2 py-1 rounded text-xs">2</kbd> for Away team</li>
             <li>• <strong>Shortcuts only work when timer is running</strong> - prevents accidental possession changes during breaks</li>

--- a/src/components/Scoreboard.tsx
+++ b/src/components/Scoreboard.tsx
@@ -15,7 +15,7 @@ export const Scoreboard: React.FC<ScoreboardProps> = ({ gameState }) => {
 
   return (
     <motion.div
-      className="w-screen h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 text-white flex items-center justify-center overflow-hidden"
+      className="w-screen h-screen bg-gradient-to-br from-gray-50 via-white to-gray-100 text-gray-900 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 dark:text-white flex items-center justify-center overflow-hidden"
       initial={{ opacity: 0, y: shouldReduceMotion ? 0 : 20 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: shouldReduceMotion ? 0 : -20 }}
@@ -23,7 +23,7 @@ export const Scoreboard: React.FC<ScoreboardProps> = ({ gameState }) => {
     >
       <div className="w-full h-full flex items-center justify-center px-8 py-6">
         {/* Main Scoreboard */}
-        <div className="bg-black/40 backdrop-blur-lg rounded-3xl border border-gray-700/50 shadow-2xl w-full max-w-7xl h-full max-h-[900px] flex flex-col justify-center p-12">
+        <div className="bg-white/60 dark:bg-black/40 backdrop-blur-lg rounded-3xl border border-gray-200 dark:border-gray-700/50 shadow-2xl w-full max-w-7xl h-full max-h-[900px] flex flex-col justify-center p-12">
           {/* Header */}
           {gameState.tournamentLogo && (
             <div className="text-center mb-12">
@@ -62,7 +62,7 @@ export const Scoreboard: React.FC<ScoreboardProps> = ({ gameState }) => {
                 <div className="text-8xl font-bold text-blue-400">{homeTeam.score}</div>
               </div>
               <div className="flex items-center justify-center gap-3">
-                <span className="text-lg text-gray-400">Fouls:</span>
+                <span className="text-lg text-gray-600 dark:text-gray-400">Fouls:</span>
                 <span className="bg-red-500/20 text-red-400 px-4 py-2 rounded-full text-xl font-semibold">
                   {homeTeam.fouls}
                 </span>
@@ -76,7 +76,7 @@ export const Scoreboard: React.FC<ScoreboardProps> = ({ gameState }) => {
                 <div className="text-7xl font-mono font-bold text-green-400 mb-4">
                   {formatTime(time.minutes, time.seconds)}
                 </div>
-                <div className="text-lg text-gray-400">
+                <div className="text-lg text-gray-600 dark:text-gray-400">
                   {getHalfName(gameState.half, gameState.gamePreset, gameState.matchPhase)}
                 </div>
               </div>
@@ -119,7 +119,7 @@ export const Scoreboard: React.FC<ScoreboardProps> = ({ gameState }) => {
                 <div className="text-8xl font-bold text-red-400">{awayTeam.score}</div>
               </div>
               <div className="flex items-center justify-center gap-3">
-                <span className="text-lg text-gray-400">Fouls:</span>
+                <span className="text-lg text-gray-600 dark:text-gray-400">Fouls:</span>
                 <span className="bg-red-500/20 text-red-400 px-4 py-2 rounded-full text-xl font-semibold">
                   {awayTeam.fouls}
                 </span>

--- a/src/components/StatsTracker.tsx
+++ b/src/components/StatsTracker.tsx
@@ -42,10 +42,10 @@ export const StatsTracker: React.FC<StatsTrackerProps> = ({
     homeValue: number;
     awayValue: number;
   }) => (
-    <div className="bg-white rounded-lg border border-gray-200 p-4">
+    <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
       <div className="flex items-center gap-2 mb-3">
-        <Icon className="w-5 h-5 text-gray-600" />
-        <h4 className="font-medium text-gray-900">{label}</h4>
+        <Icon className="w-5 h-5 text-gray-600 dark:text-gray-400" />
+        <h4 className="font-medium text-gray-900 dark:text-gray-100">{label}</h4>
       </div>
       
       <div className="grid grid-cols-2 gap-4">
@@ -97,13 +97,13 @@ export const StatsTracker: React.FC<StatsTrackerProps> = ({
   );
 
   return (
-    <div className="min-h-screen bg-gray-50 text-gray-900">
+    <div className="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
       {/* Header */}
-      <div className="bg-white shadow-sm border-b border-gray-200">
+      <div className="bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-4">
-            <h1 className="text-2xl font-bold text-gray-900">Match Statistics Tracker</h1>
-            <div className="text-sm text-gray-600">
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Match Statistics Tracker</h1>
+            <div className="text-sm text-gray-600 dark:text-gray-400">
               {homeTeam.name} vs {awayTeam.name}
             </div>
           </div>
@@ -112,19 +112,19 @@ export const StatsTracker: React.FC<StatsTrackerProps> = ({
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Ball Possession Control */}
-        <div className="bg-gradient-to-r from-green-50 to-blue-50 rounded-xl border border-green-200 p-6 mb-8">
-          <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+        <div className="bg-gradient-to-r from-green-50 to-blue-50 dark:from-green-900 dark:to-blue-900 rounded-xl border border-green-200 dark:border-green-700 p-6 mb-8">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4 flex items-center gap-2">
             <Timer className="w-5 h-5" />
             Ball Possession Control
           </h3>
-          
+
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-center">
             <button
               onClick={() => switchBallPossession('home')}
               className={`p-4 rounded-lg border-2 transition-all ${
                 ballPossession === 'home'
                   ? 'border-blue-500 bg-blue-50 text-blue-700'
-                  : 'border-gray-200 bg-white text-gray-600 hover:border-blue-300'
+                  : 'border-gray-200 bg-white text-gray-600 hover:border-blue-300 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-blue-500'
               }`}
             >
               <div className="text-center">
@@ -135,10 +135,10 @@ export const StatsTracker: React.FC<StatsTrackerProps> = ({
             </button>
 
             <div className="text-center">
-              <div className="text-sm text-gray-600 mb-2">Current Possession</div>
+              <div className="text-sm text-gray-600 dark:text-gray-400 mb-2">Current Possession</div>
               <div className={`inline-flex items-center gap-2 px-4 py-2 rounded-full font-semibold ${
-                ballPossession === 'home' 
-                  ? 'bg-blue-100 text-blue-700' 
+                ballPossession === 'home'
+                  ? 'bg-blue-100 text-blue-700'
                   : 'bg-red-100 text-red-700'
               }`}>
                 <div className={`w-2 h-2 rounded-full animate-pulse ${
@@ -146,7 +146,7 @@ export const StatsTracker: React.FC<StatsTrackerProps> = ({
                 }`}></div>
                 {ballPossession === 'home' ? homeTeam.name : awayTeam.name}
               </div>
-              <div className="mt-2 text-xs text-gray-500">
+              <div className="mt-2 text-xs text-gray-500 dark:text-gray-400">
                 Press A/1 for Home, D/2 for Away (only when timer running)
               </div>
             </div>
@@ -156,7 +156,7 @@ export const StatsTracker: React.FC<StatsTrackerProps> = ({
               className={`p-4 rounded-lg border-2 transition-all ${
                 ballPossession === 'away'
                   ? 'border-red-500 bg-red-50 text-red-700'
-                  : 'border-gray-200 bg-white text-gray-600 hover:border-red-300'
+                  : 'border-gray-200 bg-white text-gray-600 hover:border-red-300 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-red-500'
               }`}
             >
               <div className="text-center">
@@ -222,32 +222,32 @@ export const StatsTracker: React.FC<StatsTrackerProps> = ({
         </div>
 
         {/* Quick Stats Summary */}
-        <div className="mt-8 bg-white rounded-xl shadow-sm border border-gray-200 p-6">
-          <h3 className="text-lg font-semibold text-gray-900 mb-4">Match Summary</h3>
+        <div className="mt-8 bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Match Summary</h3>
           
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-center">
             <div>
-              <div className="text-sm text-gray-600">Total Shots</div>
-              <div className="text-2xl font-bold text-gray-900">
+              <div className="text-sm text-gray-600 dark:text-gray-400">Total Shots</div>
+              <div className="text-2xl font-bold text-gray-900 dark:text-gray-100">
                 {homeTeam.stats.shots + awayTeam.stats.shots}
               </div>
             </div>
             <div>
-              <div className="text-sm text-gray-600">Total Corners</div>
-              <div className="text-2xl font-bold text-gray-900">
+              <div className="text-sm text-gray-600 dark:text-gray-400">Total Corners</div>
+              <div className="text-2xl font-bold text-gray-900 dark:text-gray-100">
                 {homeTeam.stats.corners + awayTeam.stats.corners}
               </div>
             </div>
             <div>
-              <div className="text-sm text-gray-600">Total Cards</div>
-              <div className="text-2xl font-bold text-gray-900">
+              <div className="text-sm text-gray-600 dark:text-gray-400">Total Cards</div>
+              <div className="text-2xl font-bold text-gray-900 dark:text-gray-100">
                 {homeTeam.stats.yellowCards + awayTeam.stats.yellowCards + 
                  homeTeam.stats.redCards + awayTeam.stats.redCards}
               </div>
             </div>
             <div>
-              <div className="text-sm text-gray-600">Shot Accuracy</div>
-              <div className="text-2xl font-bold text-gray-900">
+              <div className="text-sm text-gray-600 dark:text-gray-400">Shot Accuracy</div>
+              <div className="text-2xl font-bold text-gray-900 dark:text-gray-100">
                 {homeTeam.stats.shots + awayTeam.stats.shots > 0 
                   ? Math.round(((homeTeam.stats.shotsOnTarget + awayTeam.stats.shotsOnTarget) / 
                       (homeTeam.stats.shots + awayTeam.stats.shots)) * 100)

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Sun, Moon } from 'lucide-react';
+
+interface ThemeToggleProps {
+  theme: 'light' | 'dark';
+  onToggle: () => void;
+}
+
+/**
+ * Floating button to toggle between light and dark themes.
+ * Appears in the top right corner on every screen.
+ */
+export const ThemeToggle: React.FC<ThemeToggleProps> = ({ theme, onToggle }) => (
+  <button
+    onClick={onToggle}
+    aria-label="Toggle dark mode"
+    className="fixed top-5 right-5 z-50 rounded-full p-2 bg-gray-200 text-gray-800 shadow-md hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 transition-colors"
+  >
+    {theme === 'dark' ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+  </button>
+);
+

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+/**
+ * Simple hook to manage application theme.
+ * Persists selection in localStorage and toggles the `dark` class
+ * on the document's root element so Tailwind's dark mode classes work.
+ */
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('theme') as Theme | null;
+      if (stored === 'dark' || stored === 'light') {
+        return stored;
+      }
+    }
+    return 'light';
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+
+  return { theme, toggleTheme };
+}
+

--- a/src/index.css
+++ b/src/index.css
@@ -7,7 +7,7 @@
     @apply h-full;
   }
   body {
-    @apply min-h-full bg-gradient-to-br from-gray-900 via-gray-800 to-black text-gray-100 antialiased;
+    @apply min-h-full bg-gradient-to-br from-gray-50 via-white to-gray-100 text-gray-900 antialiased dark:from-gray-900 dark:via-gray-800 dark:to-black dark:text-gray-100;
     font-family: 'Inter', sans-serif;
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- add theme hook and toggle button for switching between light and dark modes
- overhaul styles in core screens to support both themes
- enable Tailwind class-based dark mode and update global styles

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68934817f6e0832db0bd389cf16629d1