### PR TITLE
Fix dark mode styles for control panels

### DIFF
--- a/src/components/ExternalControlInfo.tsx
+++ b/src/components/ExternalControlInfo.tsx
@@ -3,53 +3,53 @@ import { Keyboard, Wifi, Usb, Smartphone } from 'lucide-react';
 
 export const ExternalControlInfo: React.FC = () => {
   return (
-    <div className="bg-blue-50 rounded-xl border border-blue-200 p-6">
-      <h4 className="font-semibold text-blue-900 mb-4 flex items-center gap-2">
+    <div className="bg-blue-50 rounded-xl border border-blue-200 p-6 dark:bg-blue-900 dark:border-blue-700">
+      <h4 className="font-semibold text-blue-900 mb-4 flex items-center gap-2 dark:text-blue-100">
         <Wifi className="w-5 h-5" />
         External Timer Control Options
       </h4>
-      
+
       <div className="space-y-4 text-sm">
         {/* Keyboard Shortcuts */}
-        <div className="bg-white rounded-lg p-4 border border-blue-100">
-          <h5 className="font-medium text-gray-900 mb-2 flex items-center gap-2">
+        <div className="bg-white rounded-lg p-4 border border-blue-100 dark:bg-gray-800 dark:border-blue-700">
+          <h5 className="font-medium text-gray-900 mb-2 flex items-center gap-2 dark:text-gray-100">
             <Keyboard className="w-4 h-4" />
             Keyboard Shortcuts (Built-in)
           </h5>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-2 text-xs">
             <div className="flex justify-between">
-              <span className="text-gray-600">Start/Pause:</span>
-              <kbd className="bg-gray-100 px-2 py-1 rounded">Spacebar</kbd>
+              <span className="text-gray-600 dark:text-gray-400">Start/Pause:</span>
+              <kbd className="bg-gray-100 px-2 py-1 rounded dark:bg-gray-700 dark:text-gray-200">Spacebar</kbd>
             </div>
             <div className="flex justify-between">
-              <span className="text-gray-600">Stop Timer:</span>
-              <kbd className="bg-gray-100 px-2 py-1 rounded">Esc</kbd>
+              <span className="text-gray-600 dark:text-gray-400">Stop Timer:</span>
+              <kbd className="bg-gray-100 px-2 py-1 rounded dark:bg-gray-700 dark:text-gray-200">Esc</kbd>
             </div>
             <div className="flex justify-between">
-              <span className="text-gray-600">Reset:</span>
-              <kbd className="bg-gray-100 px-2 py-1 rounded">Ctrl+R</kbd>
+              <span className="text-gray-600 dark:text-gray-400">Reset:</span>
+              <kbd className="bg-gray-100 px-2 py-1 rounded dark:bg-gray-700 dark:text-gray-200">Ctrl+R</kbd>
             </div>
             <div className="flex justify-between">
-              <span className="text-gray-600">Home Possession:</span>
-              <kbd className="bg-gray-100 px-2 py-1 rounded">A or 1</kbd>
+              <span className="text-gray-600 dark:text-gray-400">Home Possession:</span>
+              <kbd className="bg-gray-100 px-2 py-1 rounded dark:bg-gray-700 dark:text-gray-200">A or 1</kbd>
             </div>
             <div className="flex justify-between">
-              <span className="text-gray-600">Away Possession:</span>
-              <kbd className="bg-gray-100 px-2 py-1 rounded">D or 2</kbd>
+              <span className="text-gray-600 dark:text-gray-400">Away Possession:</span>
+              <kbd className="bg-gray-100 px-2 py-1 rounded dark:bg-gray-700 dark:text-gray-200">D or 2</kbd>
             </div>
-            <div className="text-xs text-gray-500 mt-2">
+            <div className="text-xs text-gray-500 mt-2 dark:text-gray-400">
               * Possession shortcuts only work when timer is running
             </div>
           </div>
         </div>
 
         {/* Hardware Options */}
-        <div className="bg-white rounded-lg p-4 border border-blue-100">
-          <h5 className="font-medium text-gray-900 mb-2 flex items-center gap-2">
+        <div className="bg-white rounded-lg p-4 border border-blue-100 dark:bg-gray-800 dark:border-blue-700">
+          <h5 className="font-medium text-gray-900 mb-2 flex items-center gap-2 dark:text-gray-100">
             <Usb className="w-4 h-4" />
             Hardware Integration Options
           </h5>
-          <ul className="space-y-2 text-gray-700">
+          <ul className="space-y-2 text-gray-700 dark:text-gray-300">
             <li>• <strong>USB Foot Pedals:</strong> Can be programmed to send spacebar/escape key presses</li>
             <li>• <strong>Wireless Presenters:</strong> Most have programmable buttons for start/stop</li>
             <li>• <strong>Game Controllers:</strong> Xbox/PlayStation controllers via USB</li>
@@ -58,26 +58,26 @@ export const ExternalControlInfo: React.FC = () => {
         </div>
 
         {/* Mobile App */}
-        <div className="bg-white rounded-lg p-4 border border-blue-100">
-          <h5 className="font-medium text-gray-900 mb-2 flex items-center gap-2">
+        <div className="bg-white rounded-lg p-4 border border-blue-100 dark:bg-gray-800 dark:border-blue-700">
+          <h5 className="font-medium text-gray-900 mb-2 flex items-center gap-2 dark:text-gray-100">
             <Smartphone className="w-4 h-4" />
             Mobile Remote Control
           </h5>
-          <p className="text-gray-700 mb-2">
+          <p className="text-gray-700 mb-2 dark:text-gray-300">
             Access this URL on any mobile device connected to the same network:
           </p>
-          <code className="bg-gray-100 px-2 py-1 rounded text-xs block">
+          <code className="bg-gray-100 px-2 py-1 rounded text-xs block dark:bg-gray-700 dark:text-gray-200">
             {window.location.origin}/remote
           </code>
-          <p className="text-gray-600 text-xs mt-1">
+          <p className="text-gray-600 text-xs mt-1 dark:text-gray-400">
             (Feature can be implemented for referee mobile control)
           </p>
         </div>
 
         {/* Professional Solutions */}
-        <div className="bg-white rounded-lg p-4 border border-blue-100">
-          <h5 className="font-medium text-gray-900 mb-2">Professional Referee Systems</h5>
-          <ul className="space-y-1 text-gray-700 text-xs">
+        <div className="bg-white rounded-lg p-4 border border-blue-100 dark:bg-gray-800 dark:border-blue-700">
+          <h5 className="font-medium text-gray-900 mb-2 dark:text-gray-100">Professional Referee Systems</h5>
+          <ul className="space-y-1 text-gray-700 text-xs dark:text-gray-300">
             <li>• <strong>Referee Watch Systems:</strong> Integrate with systems like RefLink or similar</li>
             <li>• <strong>Wireless Buzzers:</strong> Simple start/stop buttons for referees</li>
             <li>• <strong>Court-side Tablets:</strong> Dedicated control interface for officials</li>
@@ -86,9 +86,9 @@ export const ExternalControlInfo: React.FC = () => {
         </div>
       </div>
 
-      <div className="mt-4 p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
-        <p className="text-yellow-800 text-xs">
-          <strong>Quick Setup:</strong> For immediate use, any USB foot pedal or wireless presenter 
+      <div className="mt-4 p-3 bg-yellow-50 border border-yellow-200 rounded-lg dark:bg-yellow-900 dark:border-yellow-700">
+        <p className="text-yellow-800 text-xs dark:text-yellow-200">
+          <strong>Quick Setup:</strong> For immediate use, any USB foot pedal or wireless presenter
           can be configured to send spacebar presses for start/stop control.
         </p>
       </div>

--- a/src/components/GamePresetSelector.tsx
+++ b/src/components/GamePresetSelector.tsx
@@ -19,8 +19,8 @@ export const GamePresetSelector: React.FC<GamePresetSelectorProps> = ({
   };
 
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
-      <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+    <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 dark:bg-gray-800 dark:border-gray-700">
+      <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2 dark:text-gray-100">
         <Settings className="w-5 h-5 text-blue-600" />
         Game Format
       </h3>
@@ -36,18 +36,20 @@ export const GamePresetSelector: React.FC<GamePresetSelectorProps> = ({
               onClick={() => onPresetChange(index)}
               className={`p-4 rounded-lg border-2 text-left transition-all hover:shadow-md ${
                 isSelected
-                  ? 'border-blue-500 bg-blue-50 text-blue-900'
-                  : 'border-gray-200 bg-white text-gray-700 hover:border-blue-300'
+                  ? 'border-blue-500 bg-blue-50 text-blue-900 dark:bg-blue-900 dark:text-blue-100'
+                  : 'border-gray-200 bg-white text-gray-700 hover:border-blue-300 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-blue-500'
               }`}
             >
               <div className="flex items-start gap-3">
-                <Icon className={`w-5 h-5 mt-0.5 ${
-                  isSelected ? 'text-blue-600' : 'text-gray-500'
-                }`} />
+                <Icon
+                  className={`w-5 h-5 mt-0.5 ${
+                    isSelected ? 'text-blue-600' : 'text-gray-500 dark:text-gray-400'
+                  }`}
+                />
                 <div className="flex-1">
                   <h4 className="font-semibold text-sm mb-1">{preset.name}</h4>
-                  <p className="text-xs text-gray-600 mb-2">{preset.description}</p>
-                  
+                  <p className="text-xs text-gray-600 mb-2 dark:text-gray-400">{preset.description}</p>
+
                   <div className="space-y-1 text-xs">
                     <div className="flex justify-between">
                       <span>Duration:</span>
@@ -62,7 +64,7 @@ export const GamePresetSelector: React.FC<GamePresetSelectorProps> = ({
                     {preset.hasPenalties && (
                       <div className="flex justify-between">
                         <span>Penalties:</span>
-                        <span className="font-medium text-green-600">Yes</span>
+                        <span className="font-medium text-green-600 dark:text-green-400">Yes</span>
                       </div>
                     )}
                   </div>
@@ -73,23 +75,23 @@ export const GamePresetSelector: React.FC<GamePresetSelectorProps> = ({
         })}
       </div>
       
-      <div className="mt-4 p-3 bg-blue-50 rounded-lg">
-        <h4 className="font-medium text-blue-900 mb-2">Current Format: {currentPreset.name}</h4>
-        <div className="grid grid-cols-2 gap-4 text-sm text-blue-800">
+      <div className="mt-4 p-3 bg-blue-50 rounded-lg dark:bg-blue-900">
+        <h4 className="font-medium text-blue-900 mb-2 dark:text-blue-100">Current Format: {currentPreset.name}</h4>
+        <div className="grid grid-cols-2 gap-4 text-sm text-blue-800 dark:text-blue-200">
           <div>
-            <span className="text-blue-600">Half Duration:</span> {currentPreset.halfDuration} minutes
+            <span className="text-blue-600 dark:text-blue-400">Half Duration:</span> {currentPreset.halfDuration} minutes
           </div>
           <div>
-            <span className="text-blue-600">Format:</span> {currentPreset.format}
+            <span className="text-blue-600 dark:text-blue-400">Format:</span> {currentPreset.format}
           </div>
           {currentPreset.hasExtraTime && (
             <div>
-              <span className="text-blue-600">Extra Time:</span> {currentPreset.extraTimeDuration} min halves
+              <span className="text-blue-600 dark:text-blue-400">Extra Time:</span> {currentPreset.extraTimeDuration} min halves
             </div>
           )}
           {currentPreset.hasPenalties && (
             <div>
-              <span className="text-blue-600">Penalties:</span> Available
+              <span className="text-blue-600 dark:text-blue-400">Penalties:</span> Available
             </div>
           )}
         </div>

--- a/src/components/PossessionTracker.tsx
+++ b/src/components/PossessionTracker.tsx
@@ -37,9 +37,9 @@ export const PossessionTracker: React.FC<PossessionTrackerProps> = ({
             <div className="flex items-center gap-4">
               <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Match Status</h3>
               <div className={`inline-flex items-center gap-2 px-3 py-1 rounded-full ${
-                isRunning 
-                  ? 'bg-green-100 text-green-700' 
-                  : 'bg-red-100 text-red-700'
+                isRunning
+                  ? 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300'
+                  : 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300'
               }`}>
                 {isRunning ? <Play className="w-4 h-4" /> : <Pause className="w-4 h-4" />}
                 <span className="font-semibold">
@@ -50,9 +50,9 @@ export const PossessionTracker: React.FC<PossessionTrackerProps> = ({
             <div className="text-right">
               <div className="text-sm text-gray-600 dark:text-gray-400">Current Score</div>
               <div className="text-xl font-bold">
-                <span className="text-blue-600">{homeTeam.name} {homeTeam.score}</span>
+                <span className="text-blue-600 dark:text-blue-400">{homeTeam.name} {homeTeam.score}</span>
                 <span className="text-gray-400 mx-2">-</span>
-                <span className="text-red-600">{awayTeam.score} {awayTeam.name}</span>
+                <span className="text-red-600 dark:text-red-400">{awayTeam.score} {awayTeam.name}</span>
               </div>
             </div>
           </div>
@@ -71,7 +71,7 @@ export const PossessionTracker: React.FC<PossessionTrackerProps> = ({
               onClick={() => switchBallPossession('home')}
               className={`p-8 rounded-xl border-4 transition-all transform hover:scale-105 ${
                 ballPossession === 'home'
-                  ? 'border-blue-500 bg-blue-50 text-blue-700 shadow-lg'
+                  ? 'border-blue-500 bg-blue-50 text-blue-700 shadow-lg dark:bg-blue-900 dark:text-blue-100'
                   : 'border-gray-200 bg-white text-gray-600 hover:border-blue-300 hover:shadow-md dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-blue-500'
               }`}
             >
@@ -93,7 +93,7 @@ export const PossessionTracker: React.FC<PossessionTrackerProps> = ({
                 <div className="text-sm">Click for Possession (A or 1)</div>
                 <div className="text-2xl font-bold">{homeTeam.stats.possession}%</div>
                 {ballPossession === 'home' && (
-                  <div className="mt-2 text-xs font-semibold text-blue-600">
+                  <div className="mt-2 text-xs font-semibold text-blue-600 dark:text-blue-400">
                     ● CURRENT POSSESSION
                   </div>
                 )}
@@ -104,9 +104,9 @@ export const PossessionTracker: React.FC<PossessionTrackerProps> = ({
             <div className="text-center">
               <div className="text-sm text-gray-600 dark:text-gray-400 mb-3">Current Ball Possession</div>
               <div className={`inline-flex items-center gap-3 px-6 py-4 rounded-full font-bold text-lg ${
-                ballPossession === 'home' 
-                  ? 'bg-blue-100 text-blue-700 border-2 border-blue-300' 
-                  : 'bg-red-100 text-red-700 border-2 border-red-300'
+                ballPossession === 'home'
+                  ? 'bg-blue-100 text-blue-700 border-2 border-blue-300 dark:bg-blue-900 dark:text-blue-300 dark:border-blue-700'
+                  : 'bg-red-100 text-red-700 border-2 border-red-300 dark:bg-red-900 dark:text-red-300 dark:border-red-700'
               }`}>
                 <div className={`w-3 h-3 rounded-full animate-pulse ${
                   ballPossession === 'home' ? 'bg-blue-500' : 'bg-red-500'
@@ -124,7 +124,7 @@ export const PossessionTracker: React.FC<PossessionTrackerProps> = ({
               onClick={() => switchBallPossession('away')}
               className={`p-8 rounded-xl border-4 transition-all transform hover:scale-105 ${
                 ballPossession === 'away'
-                  ? 'border-red-500 bg-red-50 text-red-700 shadow-lg'
+                  ? 'border-red-500 bg-red-50 text-red-700 shadow-lg dark:bg-red-900 dark:text-red-100'
                   : 'border-gray-200 bg-white text-gray-600 hover:border-red-300 hover:shadow-md dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-red-500'
               }`}
             >
@@ -146,7 +146,7 @@ export const PossessionTracker: React.FC<PossessionTrackerProps> = ({
                 <div className="text-sm mb-2">Click for Possession (D or 2)</div>
                 <div className="text-2xl font-bold">{awayTeam.stats.possession}%</div>
                 {ballPossession === 'away' && (
-                  <div className="mt-2 text-xs font-semibold text-red-600">
+                  <div className="mt-2 text-xs font-semibold text-red-600 dark:text-red-400">
                     ● CURRENT POSSESSION
                   </div>
                 )}
@@ -189,7 +189,17 @@ export const PossessionTracker: React.FC<PossessionTrackerProps> = ({
           <h4 className="font-semibold text-green-900 dark:text-green-100 mb-3">Operator Instructions</h4>
           <ul className="space-y-2 text-sm text-green-800 dark:text-green-200">
             <li>• <strong>Click team buttons</strong> to switch ball possession when play changes</li>
-            <li>• <strong>Keyboard shortcuts</strong>: Press <kbd className="bg-green-100 px-2 py-1 rounded text-xs">A</kbd> or <kbd className="bg-green-100 px-2 py-1 rounded text-xs">1</kbd> for Home team, <kbd className="bg-green-100 px-2 py-1 rounded text-xs">D</kbd> or <kbd className="bg-green-100 px-2 py-1 rounded text-xs">2</kbd> for Away team</li>
+            <li>
+              • <strong>Keyboard shortcuts</strong>: Press
+              <kbd className="bg-green-100 px-2 py-1 rounded text-xs dark:bg-green-800 dark:text-green-100">A</kbd>
+              or
+              <kbd className="bg-green-100 px-2 py-1 rounded text-xs dark:bg-green-800 dark:text-green-100">1</kbd>
+              for Home team,
+              <kbd className="bg-green-100 px-2 py-1 rounded text-xs dark:bg-green-800 dark:text-green-100">D</kbd>
+              or
+              <kbd className="bg-green-100 px-2 py-1 rounded text-xs dark:bg-green-800 dark:text-green-100">2</kbd>
+              for Away team
+            </li>
             <li>• <strong>Shortcuts only work when timer is running</strong> - prevents accidental possession changes during breaks</li>
             <li>• <strong>Possession percentages</strong> are calculated automatically based on time</li>
             <li>• <strong>Only track possession changes</strong> - other operators handle different stats</li>

--- a/src/components/StatsTracker.tsx
+++ b/src/components/StatsTracker.tsx
@@ -47,24 +47,24 @@ export const StatsTracker: React.FC<StatsTrackerProps> = ({
         <Icon className="w-5 h-5 text-gray-600 dark:text-gray-400" />
         <h4 className="font-medium text-gray-900 dark:text-gray-100">{label}</h4>
       </div>
-      
+
       <div className="grid grid-cols-2 gap-4">
         {/* Home Team */}
         <div className="text-center">
-          <div className="text-sm text-blue-600 font-medium mb-2">{homeTeam.name}</div>
+          <div className="text-sm text-blue-600 font-medium mb-2 dark:text-blue-400">{homeTeam.name}</div>
           <div className="flex items-center justify-center gap-2">
             <button
               onClick={() => adjustStat('home', stat, -1)}
-              className="w-8 h-8 bg-red-100 text-red-600 rounded-lg hover:bg-red-200 flex items-center justify-center transition-colors"
+              className="w-8 h-8 bg-red-100 text-red-600 rounded-lg hover:bg-red-200 flex items-center justify-center transition-colors dark:bg-red-900 dark:text-red-400 dark:hover:bg-red-800"
             >
               <Minus className="w-4 h-4" />
             </button>
-            <span className="text-xl font-bold text-blue-600 min-w-[2rem]">
+            <span className="text-xl font-bold text-blue-600 min-w-[2rem] dark:text-blue-400">
               {stat === 'possession' ? `${homeValue}%` : homeValue}
             </span>
             <button
               onClick={() => adjustStat('home', stat, 1)}
-              className="w-8 h-8 bg-green-100 text-green-600 rounded-lg hover:bg-green-200 flex items-center justify-center transition-colors"
+              className="w-8 h-8 bg-green-100 text-green-600 rounded-lg hover:bg-green-200 flex items-center justify-center transition-colors dark:bg-green-900 dark:text-green-400 dark:hover:bg-green-800"
             >
               <Plus className="w-4 h-4" />
             </button>
@@ -73,20 +73,20 @@ export const StatsTracker: React.FC<StatsTrackerProps> = ({
 
         {/* Away Team */}
         <div className="text-center">
-          <div className="text-sm text-red-600 font-medium mb-2">{awayTeam.name}</div>
+          <div className="text-sm text-red-600 font-medium mb-2 dark:text-red-400">{awayTeam.name}</div>
           <div className="flex items-center justify-center gap-2">
             <button
               onClick={() => adjustStat('away', stat, -1)}
-              className="w-8 h-8 bg-red-100 text-red-600 rounded-lg hover:bg-red-200 flex items-center justify-center transition-colors"
+              className="w-8 h-8 bg-red-100 text-red-600 rounded-lg hover:bg-red-200 flex items-center justify-center transition-colors dark:bg-red-900 dark:text-red-400 dark:hover:bg-red-800"
             >
               <Minus className="w-4 h-4" />
             </button>
-            <span className="text-xl font-bold text-red-600 min-w-[2rem]">
+            <span className="text-xl font-bold text-red-600 min-w-[2rem] dark:text-red-400">
               {stat === 'possession' ? `${awayValue}%` : awayValue}
             </span>
             <button
               onClick={() => adjustStat('away', stat, 1)}
-              className="w-8 h-8 bg-green-100 text-green-600 rounded-lg hover:bg-green-200 flex items-center justify-center transition-colors"
+              className="w-8 h-8 bg-green-100 text-green-600 rounded-lg hover:bg-green-200 flex items-center justify-center transition-colors dark:bg-green-900 dark:text-green-400 dark:hover:bg-green-800"
             >
               <Plus className="w-4 h-4" />
             </button>
@@ -123,7 +123,7 @@ export const StatsTracker: React.FC<StatsTrackerProps> = ({
               onClick={() => switchBallPossession('home')}
               className={`p-4 rounded-lg border-2 transition-all ${
                 ballPossession === 'home'
-                  ? 'border-blue-500 bg-blue-50 text-blue-700'
+                  ? 'border-blue-500 bg-blue-50 text-blue-700 dark:bg-blue-900 dark:text-blue-300'
                   : 'border-gray-200 bg-white text-gray-600 hover:border-blue-300 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-blue-500'
               }`}
             >
@@ -138,8 +138,8 @@ export const StatsTracker: React.FC<StatsTrackerProps> = ({
               <div className="text-sm text-gray-600 dark:text-gray-400 mb-2">Current Possession</div>
               <div className={`inline-flex items-center gap-2 px-4 py-2 rounded-full font-semibold ${
                 ballPossession === 'home'
-                  ? 'bg-blue-100 text-blue-700'
-                  : 'bg-red-100 text-red-700'
+                  ? 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300'
+                  : 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300'
               }`}>
                 <div className={`w-2 h-2 rounded-full animate-pulse ${
                   ballPossession === 'home' ? 'bg-blue-500' : 'bg-red-500'
@@ -155,7 +155,7 @@ export const StatsTracker: React.FC<StatsTrackerProps> = ({
               onClick={() => switchBallPossession('away')}
               className={`p-4 rounded-lg border-2 transition-all ${
                 ballPossession === 'away'
-                  ? 'border-red-500 bg-red-50 text-red-700'
+                  ? 'border-red-500 bg-red-50 text-red-700 dark:bg-red-900 dark:text-red-300'
                   : 'border-gray-200 bg-white text-gray-600 hover:border-red-300 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-red-500'
               }`}
             >


### PR DESCRIPTION
## Summary
- ensure external control info and game preset selector honor dark mode themes
- update stats and possession trackers with dark-friendly buttons and indicators

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68934c0ce7bc832d8b4936480dbb025e