### PR TITLE
feat: show timer state in stats tracker

### DIFF
--- a/src/components/StatsTracker.tsx
+++ b/src/components/StatsTracker.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { GameState, Team } from '../types';
-import { 
-  Plus, 
-  Minus, 
+import {
+  Plus,
+  Minus,
   Target,
   CornerDownLeft,
   Flag,
@@ -10,6 +10,7 @@ import {
   Square,
   Timer
 } from 'lucide-react';
+import { formatTime } from '../utils/format';
 
 interface StatsTrackerProps {
   gameState: GameState;
@@ -103,8 +104,23 @@ export const StatsTracker: React.FC<StatsTrackerProps> = ({
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-4">
             <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Match Statistics Tracker</h1>
-            <div className="text-sm text-gray-600 dark:text-gray-400">
-              {homeTeam.name} vs {awayTeam.name}
+            <div className="flex items-center gap-6 text-sm text-gray-600 dark:text-gray-400">
+              <div>
+                {homeTeam.name} vs {awayTeam.name}
+              </div>
+              <div className="flex items-center gap-2">
+                <Timer className="w-4 h-4" />
+                <span>{formatTime(gameState.time.minutes, gameState.time.seconds)}</span>
+              </div>
+              <div
+                className={`px-2 py-1 rounded-full font-medium ${
+                  gameState.isRunning
+                    ? 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300'
+                    : 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300'
+                }`}
+              >
+                {gameState.isRunning ? 'Live' : 'Paused'}
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- show current match time and status in statistics tracker header
- import `formatTime` utility to render time

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689364b52ec0832d9f5c88c043e7482f