### PR TITLE
Remove possession display from overlay

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,7 @@ function App() {
       <ThemeToggle theme={theme} onToggle={toggleTheme} />
       {viewMode === 'overlay' ? (
         <div className="relative min-h-screen bg-transparent">
-          <Overlay gameState={gameState.gameState} showStats />
+          <Overlay gameState={gameState.gameState} />
           {/* Floating control button */}
           <ControlPanelButton onClick={() => setViewMode('dashboard')} />
         </div>

--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -9,7 +9,7 @@ interface OverlayProps {
   showStats?: boolean;
 }
 
-export const Overlay: React.FC<OverlayProps> = ({ gameState, showStats = true }) => {
+export const Overlay: React.FC<OverlayProps> = ({ gameState, showStats = false }) => {
   const shouldReduceMotion = useReducedMotion();
   if (!gameState) return null;
 
@@ -96,18 +96,12 @@ export const Overlay: React.FC<OverlayProps> = ({ gameState, showStats = true })
                   <span className="text-blue-600 dark:text-blue-400 font-medium">{homeTeam.name}</span>
                   <span className="text-gray-600 dark:text-white/60">Fouls:</span>
                   <span className="text-red-600 dark:text-red-400 font-bold">{homeTeam.fouls}</span>
-                  <span className="text-gray-600 dark:text-white/60">|</span>
-                  <span className="text-gray-600 dark:text-white/60">Poss:</span>
-                  <span className="text-blue-600 dark:text-blue-400 font-bold">{homeTeam.stats.possession}%</span>
                 </div>
                 <div className="w-px h-4 bg-gray-300 dark:bg-white/20"></div>
                 <div className="flex items-center gap-2">
                   <span className="text-red-600 dark:text-red-400 font-medium">{awayTeam.name}</span>
                   <span className="text-gray-600 dark:text-white/60">Fouls:</span>
                   <span className="text-red-600 dark:text-red-400 font-bold">{awayTeam.fouls}</span>
-                  <span className="text-gray-600 dark:text-white/60">|</span>
-                  <span className="text-gray-600 dark:text-white/60">Poss:</span>
-                  <span className="text-red-600 dark:text-red-400 font-bold">{awayTeam.stats.possession}%</span>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- default overlay to hide stats unless explicitly enabled
- strip possession data from overlay stats bar and show fouls only
- update app overlay usage to exclude stat display

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68936ab0c99c832d874f5041fd4f1973