### PR TITLE
docs: expand feature overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,15 @@ A modern React + TypeScript scoreboard for tracking futsal matches with a polish
 - Animated transitions for scores, timer, and live indicators
 - Route-based views for dashboard, scoreboard, statistics, and overlays
 - Progressive Web App (PWA) support so the app can be installed on devices
+- Detailed stats tracker with shot accuracy, cards, and corner tracking
+- Dedicated ball possession operator interface with keyboard shortcuts (A/1 for home, D/2 for away)
+- External timer control options: keyboard shortcuts, hardware integration, and potential mobile remote
 
 ## Screenshots
 
 ![Dashboard view](docs/ui-dashboard.svg)
+![Stats tracker](docs/ui-stats.svg)
+![Possession interface](docs/ui-possession.svg)
 ![Dark mode](docs/ui-dark-mode.svg)
 
 ## Setup

--- a/docs/ui-possession.svg
+++ b/docs/ui-possession.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="450">
+  <rect width="100%" height="100%" fill="#e2e8f0"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="32" fill="#1e293b">Possession View</text>
+</svg>

--- a/docs/ui-stats.svg
+++ b/docs/ui-stats.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="450">
+  <rect width="100%" height="100%" fill="#f8fafc"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="32" fill="#0f172a">Stats View</text>
+</svg>


### PR DESCRIPTION
## Summary
- expand Feature Overview with stats tracker, possession interface, and external timer control details
- document stats and possession screenshots

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68937a0c224c832db26414b2781fd812