### PR TITLE
Add remote control component and route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { StatsTracker } from './components/StatsTracker';
 import { PossessionTracker } from './components/PossessionTracker';
 import { ControlPanelButton } from './components/ControlPanelButton';
 import { ThemeToggle } from './components/ThemeToggle';
+import { RemoteControl } from './components/RemoteControl';
 
 type ViewMode = 'scoreboard' | 'dashboard' | 'overlay' | 'stats' | 'possession';
 
@@ -19,6 +20,10 @@ function App() {
   const handleViewChange = (view: ViewMode) => {
     setViewMode(view);
   };
+
+  if (window.location.pathname === '/remote') {
+    return <RemoteControl />;
+  }
 
   return (
     <div className="App">

--- a/src/components/RemoteControl.tsx
+++ b/src/components/RemoteControl.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { useGameState } from '../hooks/useGameState';
+
+export const RemoteControl: React.FC = () => {
+  const { gameState, toggleTimer, updateTeam } = useGameState();
+
+  return (
+    <div className="p-4 space-y-8">
+      <div className="text-center">
+        <button
+          onClick={toggleTimer}
+          className="px-4 py-2 bg-indigo-600 text-white rounded"
+        >
+          {gameState.isRunning ? 'Pause' : 'Start'} Timer
+        </button>
+      </div>
+
+      <div className="grid grid-cols-2 gap-8">
+        <div>
+          <h2 className="font-semibold text-center mb-2">{gameState.homeTeam.name}</h2>
+          <div className="flex justify-center gap-2 mb-4">
+            <button
+              onClick={() => updateTeam('home', 'score', gameState.homeTeam.score + 1)}
+              className="px-3 py-1 bg-green-500 text-white rounded"
+            >
+              + Score
+            </button>
+            <button
+              onClick={() => updateTeam('home', 'score', Math.max(0, gameState.homeTeam.score - 1))}
+              className="px-3 py-1 bg-red-500 text-white rounded"
+            >
+              - Score
+            </button>
+          </div>
+          <div className="flex justify-center gap-2">
+            <button
+              onClick={() => updateTeam('home', 'fouls', gameState.homeTeam.fouls + 1)}
+              className="px-3 py-1 bg-yellow-500 text-white rounded"
+            >
+              + Foul
+            </button>
+            <button
+              onClick={() => updateTeam('home', 'fouls', Math.max(0, gameState.homeTeam.fouls - 1))}
+              className="px-3 py-1 bg-gray-500 text-white rounded"
+            >
+              - Foul
+            </button>
+          </div>
+        </div>
+
+        <div>
+          <h2 className="font-semibold text-center mb-2">{gameState.awayTeam.name}</h2>
+          <div className="flex justify-center gap-2 mb-4">
+            <button
+              onClick={() => updateTeam('away', 'score', gameState.awayTeam.score + 1)}
+              className="px-3 py-1 bg-green-500 text-white rounded"
+            >
+              + Score
+            </button>
+            <button
+              onClick={() => updateTeam('away', 'score', Math.max(0, gameState.awayTeam.score - 1))}
+              className="px-3 py-1 bg-red-500 text-white rounded"
+            >
+              - Score
+            </button>
+          </div>
+          <div className="flex justify-center gap-2">
+            <button
+              onClick={() => updateTeam('away', 'fouls', gameState.awayTeam.fouls + 1)}
+              className="px-3 py-1 bg-yellow-500 text-white rounded"
+            >
+              + Foul
+            </button>
+            <button
+              onClick={() => updateTeam('away', 'fouls', Math.max(0, gameState.awayTeam.fouls - 1))}
+              className="px-3 py-1 bg-gray-500 text-white rounded"
+            >
+              - Foul
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RemoteControl;
+


### PR DESCRIPTION
## Summary
- add RemoteControl component to adjust timer, scores, and fouls
- display RemoteControl when visiting `/remote`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689383b1f1e4832d82882e2c4beebdfe