### PR TITLE
feat: add player tracking

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ function App() {
             gameState={gameState.gameState}
             updateTeamStats={gameState.updateTeamStats}
             updateTeamScore={(team, value) => gameState.updateTeam(team, 'score', value)}
+            updatePlayerStats={gameState.updatePlayerStats}
             switchBallPossession={gameState.switchBallPossession}
             undo={gameState.undo}
             redo={gameState.redo}
@@ -75,6 +76,8 @@ function App() {
           resetGame={gameState.resetGame}
           undo={gameState.undo}
           redo={gameState.redo}
+          addPlayer={gameState.addPlayer}
+          removePlayer={gameState.removePlayer}
           onViewChange={handleViewChange}
         />
       )}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -29,6 +29,8 @@ interface DashboardProps {
   resetGame: () => void;
   undo: () => void;
   redo: () => void;
+  addPlayer: (team: 'home' | 'away', name: string) => void;
+  removePlayer: (team: 'home' | 'away', playerId: string) => void;
   onViewChange: (view: 'scoreboard' | 'dashboard' | 'overlay' | 'stats' | 'possession') => void;
 }
 
@@ -44,6 +46,8 @@ export const Dashboard: React.FC<DashboardProps> = ({
   resetGame,
   undo,
   redo,
+  addPlayer,
+  removePlayer,
   onViewChange,
 }) => {
   const [activeTab, setActiveTab] = useState<'teams' | 'timer' | 'format' | 'settings'>('teams');
@@ -52,6 +56,8 @@ export const Dashboard: React.FC<DashboardProps> = ({
   const [homeLogoError, setHomeLogoError] = useState('');
   const [awayLogoError, setAwayLogoError] = useState('');
   const [tournamentLogoError, setTournamentLogoError] = useState('');
+  const [homePlayerName, setHomePlayerName] = useState('');
+  const [awayPlayerName, setAwayPlayerName] = useState('');
 
   const handleImageUpload = (team: 'home' | 'away', event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -374,6 +380,47 @@ export const Dashboard: React.FC<DashboardProps> = ({
                     </button>
                   </div>
                 </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Players</label>
+                  <div className="flex gap-2 mb-2">
+                    <input
+                      type="text"
+                      value={homePlayerName}
+                      onChange={(e) => setHomePlayerName(e.target.value)}
+                      placeholder="Player name"
+                      className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-gray-100"
+                    />
+                    <button
+                      onClick={() => {
+                        if (homePlayerName.trim()) {
+                          addPlayer('home', homePlayerName.trim());
+                          setHomePlayerName('');
+                        }
+                      }}
+                      className="px-3 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+                    >
+                      Add
+                    </button>
+                  </div>
+                  <ul className="space-y-1 max-h-40 overflow-y-auto">
+                    {gameState.homeTeam.players.map((p) => (
+                      <li
+                        key={p.id}
+                        className="flex items-center justify-between text-sm text-gray-700 dark:text-gray-300"
+                      >
+                        <span>
+                          {p.name} - G:{p.goals} YC:{p.yellowCards} RC:{p.redCards}
+                        </span>
+                        <button
+                          onClick={() => removePlayer('home', p.id)}
+                          className="text-red-500 hover:text-red-700"
+                        >
+                          Remove
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
               </div>
             </div>
 
@@ -458,6 +505,47 @@ export const Dashboard: React.FC<DashboardProps> = ({
                       <Plus className="w-4 h-4" />
                     </button>
                   </div>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Players</label>
+                  <div className="flex gap-2 mb-2">
+                    <input
+                      type="text"
+                      value={awayPlayerName}
+                      onChange={(e) => setAwayPlayerName(e.target.value)}
+                      placeholder="Player name"
+                      className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-red-500 dark:bg-gray-700 dark:text-gray-100"
+                    />
+                    <button
+                      onClick={() => {
+                        if (awayPlayerName.trim()) {
+                          addPlayer('away', awayPlayerName.trim());
+                          setAwayPlayerName('');
+                        }
+                      }}
+                      className="px-3 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"
+                    >
+                      Add
+                    </button>
+                  </div>
+                  <ul className="space-y-1 max-h-40 overflow-y-auto">
+                    {gameState.awayTeam.players.map((p) => (
+                      <li
+                        key={p.id}
+                        className="flex items-center justify-between text-sm text-gray-700 dark:text-gray-300"
+                      >
+                        <span>
+                          {p.name} - G:{p.goals} YC:{p.yellowCards} RC:{p.redCards}
+                        </span>
+                        <button
+                          onClick={() => removePlayer('away', p.id)}
+                          className="text-red-500 hover:text-red-700"
+                        >
+                          Remove
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
                 </div>
               </div>
             </div>

--- a/src/components/StatsTracker.tsx
+++ b/src/components/StatsTracker.tsx
@@ -19,6 +19,12 @@ interface StatsTrackerProps {
   gameState: GameState;
   updateTeamStats: (team: 'home' | 'away', stat: keyof Team['stats'], value: number) => void;
   updateTeamScore: (team: 'home' | 'away', value: number) => void;
+  updatePlayerStats: (
+    team: 'home' | 'away',
+    playerId: string,
+    field: 'goals' | 'yellowCards' | 'redCards',
+    value: number,
+  ) => void;
   switchBallPossession: (team: 'home' | 'away') => void;
   undo: () => void;
   redo: () => void;
@@ -28,6 +34,7 @@ export const StatsTracker: React.FC<StatsTrackerProps> = ({
   gameState,
   updateTeamStats,
   updateTeamScore,
+  updatePlayerStats,
   switchBallPossession,
   undo,
   redo,
@@ -108,6 +115,20 @@ export const StatsTracker: React.FC<StatsTrackerProps> = ({
     if (!gameState.isRunning) return;
     const currentScore = gameState[team === 'home' ? 'homeTeam' : 'awayTeam'].score;
     updateTeamScore(team, Math.max(0, currentScore + delta));
+  };
+
+  const adjustPlayerStat = (
+    team: 'home' | 'away',
+    playerId: string,
+    field: 'goals' | 'yellowCards' | 'redCards',
+    delta: number,
+  ) => {
+    if (!gameState.isRunning) return;
+    const teamObj = team === 'home' ? homeTeam : awayTeam;
+    const player = teamObj.players.find(p => p.id === playerId);
+    if (!player) return;
+    const newValue = Math.max(0, player[field] + delta);
+    updatePlayerStats(team, playerId, field, newValue);
   };
 
   const StatControl = ({ 
@@ -424,6 +445,167 @@ export const StatsTracker: React.FC<StatsTrackerProps> = ({
             homeValue={homeTeam.stats.redCards}
             awayValue={awayTeam.stats.redCards}
           />
+        </div>
+
+        {/* Player Stats */}
+        <div className="mt-8">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Player Stats</h3>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+              <h4 className="text-center font-medium text-blue-600 dark:text-blue-400 mb-4">{homeTeam.name}</h4>
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-gray-600 dark:text-gray-400">
+                    <th className="text-left">Player</th>
+                    <th className="text-center">G</th>
+                    <th className="text-center">YC</th>
+                    <th className="text-center">RC</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {homeTeam.players.map(p => (
+                    <tr key={p.id} className="text-gray-700 dark:text-gray-300">
+                      <td className="py-1">{p.name}</td>
+                      <td className="py-1">
+                        <div className="flex items-center justify-center gap-1">
+                          <button
+                            onClick={() => adjustPlayerStat('home', p.id, 'goals', -1)}
+                            disabled={!gameState.isRunning}
+                            className={`w-6 h-6 bg-red-100 text-red-600 rounded flex items-center justify-center dark:bg-red-900 dark:text-red-400 ${gameState.isRunning ? 'hover:bg-red-200 dark:hover:bg-red-800' : 'opacity-50 cursor-not-allowed'}`}
+                          >
+                            <Minus className="w-3 h-3" />
+                          </button>
+                          <span>{p.goals}</span>
+                          <button
+                            onClick={() => adjustPlayerStat('home', p.id, 'goals', 1)}
+                            disabled={!gameState.isRunning}
+                            className={`w-6 h-6 bg-green-100 text-green-600 rounded flex items-center justify-center dark:bg-green-900 dark:text-green-400 ${gameState.isRunning ? 'hover:bg-green-200 dark:hover:bg-green-800' : 'opacity-50 cursor-not-allowed'}`}
+                          >
+                            <Plus className="w-3 h-3" />
+                          </button>
+                        </div>
+                      </td>
+                      <td className="py-1">
+                        <div className="flex items-center justify-center gap-1">
+                          <button
+                            onClick={() => adjustPlayerStat('home', p.id, 'yellowCards', -1)}
+                            disabled={!gameState.isRunning}
+                            className={`w-6 h-6 bg-red-100 text-red-600 rounded flex items-center justify-center dark:bg-red-900 dark:text-red-400 ${gameState.isRunning ? 'hover:bg-red-200 dark:hover:bg-red-800' : 'opacity-50 cursor-not-allowed'}`}
+                          >
+                            <Minus className="w-3 h-3" />
+                          </button>
+                          <span>{p.yellowCards}</span>
+                          <button
+                            onClick={() => adjustPlayerStat('home', p.id, 'yellowCards', 1)}
+                            disabled={!gameState.isRunning}
+                            className={`w-6 h-6 bg-green-100 text-green-600 rounded flex items-center justify-center dark:bg-green-900 dark:text-green-400 ${gameState.isRunning ? 'hover:bg-green-200 dark:hover:bg-green-800' : 'opacity-50 cursor-not-allowed'}`}
+                          >
+                            <Plus className="w-3 h-3" />
+                          </button>
+                        </div>
+                      </td>
+                      <td className="py-1">
+                        <div className="flex items-center justify-center gap-1">
+                          <button
+                            onClick={() => adjustPlayerStat('home', p.id, 'redCards', -1)}
+                            disabled={!gameState.isRunning}
+                            className={`w-6 h-6 bg-red-100 text-red-600 rounded flex items-center justify-center dark:bg-red-900 dark:text-red-400 ${gameState.isRunning ? 'hover:bg-red-200 dark:hover:bg-red-800' : 'opacity-50 cursor-not-allowed'}`}
+                          >
+                            <Minus className="w-3 h-3" />
+                          </button>
+                          <span>{p.redCards}</span>
+                          <button
+                            onClick={() => adjustPlayerStat('home', p.id, 'redCards', 1)}
+                            disabled={!gameState.isRunning}
+                            className={`w-6 h-6 bg-green-100 text-green-600 rounded flex items-center justify-center dark:bg-green-900 dark:text-green-400 ${gameState.isRunning ? 'hover:bg-green-200 dark:hover:bg-green-800' : 'opacity-50 cursor-not-allowed'}`}
+                          >
+                            <Plus className="w-3 h-3" />
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+              <h4 className="text-center font-medium text-red-600 dark:text-red-400 mb-4">{awayTeam.name}</h4>
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-gray-600 dark:text-gray-400">
+                    <th className="text-left">Player</th>
+                    <th className="text-center">G</th>
+                    <th className="text-center">YC</th>
+                    <th className="text-center">RC</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {awayTeam.players.map(p => (
+                    <tr key={p.id} className="text-gray-700 dark:text-gray-300">
+                      <td className="py-1">{p.name}</td>
+                      <td className="py-1">
+                        <div className="flex items-center justify-center gap-1">
+                          <button
+                            onClick={() => adjustPlayerStat('away', p.id, 'goals', -1)}
+                            disabled={!gameState.isRunning}
+                            className={`w-6 h-6 bg-red-100 text-red-600 rounded flex items-center justify-center dark:bg-red-900 dark:text-red-400 ${gameState.isRunning ? 'hover:bg-red-200 dark:hover:bg-red-800' : 'opacity-50 cursor-not-allowed'}`}
+                          >
+                            <Minus className="w-3 h-3" />
+                          </button>
+                          <span>{p.goals}</span>
+                          <button
+                            onClick={() => adjustPlayerStat('away', p.id, 'goals', 1)}
+                            disabled={!gameState.isRunning}
+                            className={`w-6 h-6 bg-green-100 text-green-600 rounded flex items-center justify-center dark:bg-green-900 dark:text-green-400 ${gameState.isRunning ? 'hover:bg-green-200 dark:hover:bg-green-800' : 'opacity-50 cursor-not-allowed'}`}
+                          >
+                            <Plus className="w-3 h-3" />
+                          </button>
+                        </div>
+                      </td>
+                      <td className="py-1">
+                        <div className="flex items-center justify-center gap-1">
+                          <button
+                            onClick={() => adjustPlayerStat('away', p.id, 'yellowCards', -1)}
+                            disabled={!gameState.isRunning}
+                            className={`w-6 h-6 bg-red-100 text-red-600 rounded flex items-center justify-center dark:bg-red-900 dark:text-red-400 ${gameState.isRunning ? 'hover:bg-red-200 dark:hover:bg-red-800' : 'opacity-50 cursor-not-allowed'}`}
+                          >
+                            <Minus className="w-3 h-3" />
+                          </button>
+                          <span>{p.yellowCards}</span>
+                          <button
+                            onClick={() => adjustPlayerStat('away', p.id, 'yellowCards', 1)}
+                            disabled={!gameState.isRunning}
+                            className={`w-6 h-6 bg-green-100 text-green-600 rounded flex items-center justify-center dark:bg-green-900 dark:text-green-400 ${gameState.isRunning ? 'hover:bg-green-200 dark:hover:bg-green-800' : 'opacity-50 cursor-not-allowed'}`}
+                          >
+                            <Plus className="w-3 h-3" />
+                          </button>
+                        </div>
+                      </td>
+                      <td className="py-1">
+                        <div className="flex items-center justify-center gap-1">
+                          <button
+                            onClick={() => adjustPlayerStat('away', p.id, 'redCards', -1)}
+                            disabled={!gameState.isRunning}
+                            className={`w-6 h-6 bg-red-100 text-red-600 rounded flex items-center justify-center dark:bg-red-900 dark:text-red-400 ${gameState.isRunning ? 'hover:bg-red-200 dark:hover:bg-red-800' : 'opacity-50 cursor-not-allowed'}`}
+                          >
+                            <Minus className="w-3 h-3" />
+                          </button>
+                          <span>{p.redCards}</span>
+                          <button
+                            onClick={() => adjustPlayerStat('away', p.id, 'redCards', 1)}
+                            disabled={!gameState.isRunning}
+                            className={`w-6 h-6 bg-green-100 text-green-600 rounded flex items-center justify-center dark:bg-green-900 dark:text-green-400 ${gameState.isRunning ? 'hover:bg-green-200 dark:hover:bg-green-800' : 'opacity-50 cursor-not-allowed'}`}
+                          >
+                            <Plus className="w-3 h-3" />
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
         </div>
 
         {/* Quick Stats Summary */}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,12 @@
+export interface Player {
+  id: string;
+  name: string;
+  number?: number;
+  goals: number;
+  yellowCards: number;
+  redCards: number;
+}
+
 export interface Team {
   name: string;
   logo?: string;
@@ -12,6 +21,7 @@ export interface Team {
     redCards: number;
     possession: number; // percentage
   };
+  players: Player[];
 }
 
 export type GameType = 'football' | 'futsal';


### PR DESCRIPTION
## Summary
- add Player type with per-team player arrays
- manage players and stats in useGameState hook
- track individual player goals/cards in dashboard and stats tracker

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689387b19648832dad17dc1651faeb9b