### PR TITLE
feat: merge stored game state with defaults

### DIFF
--- a/src/hooks/useGameState.test.ts
+++ b/src/hooks/useGameState.test.ts
@@ -41,3 +41,25 @@ describe('useGameState history', () => {
   });
 });
 
+describe('useGameState initialization', () => {
+  it('merges stored state with defaults', () => {
+    const partial = {
+      homeTeam: { name: 'Saved Home' },
+      awayTeam: { name: 'Saved Away' },
+      time: { minutes: 15 },
+    };
+    window.localStorage.setItem('gameState', JSON.stringify(partial));
+
+    const { result } = renderHook(() => useGameState());
+
+    expect(result.current.gameState.homeTeam.name).toBe('Saved Home');
+    expect(result.current.gameState.awayTeam.name).toBe('Saved Away');
+    expect(result.current.gameState.homeTeam.players).toEqual([]);
+    expect(result.current.gameState.awayTeam.players).toEqual([]);
+    expect(result.current.gameState.time.minutes).toBe(15);
+    expect(result.current.gameState.time.seconds).toBe(0);
+
+    window.localStorage.removeItem('gameState');
+  });
+});
+

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -93,7 +93,41 @@ export const useGameState = () => {
       const stored = window.localStorage.getItem(STORAGE_KEY);
       if (stored) {
         try {
-          return JSON.parse(stored) as GameState;
+          const parsed = JSON.parse(stored) as Partial<GameState>;
+          return {
+            ...initialState,
+            ...parsed,
+            homeTeam: {
+              ...initialState.homeTeam,
+              ...parsed.homeTeam,
+              stats: {
+                ...initialState.homeTeam.stats,
+                ...parsed.homeTeam?.stats,
+              },
+              players: parsed.homeTeam?.players ?? [],
+            },
+            awayTeam: {
+              ...initialState.awayTeam,
+              ...parsed.awayTeam,
+              stats: {
+                ...initialState.awayTeam.stats,
+                ...parsed.awayTeam?.stats,
+              },
+              players: parsed.awayTeam?.players ?? [],
+            },
+            time: {
+              ...initialState.time,
+              ...parsed.time,
+            },
+            totalPossessionTime: {
+              ...initialState.totalPossessionTime,
+              ...parsed.totalPossessionTime,
+            },
+            gamePreset: {
+              ...initialState.gamePreset,
+              ...parsed.gamePreset,
+            },
+          } as GameState;
         } catch {
           // ignore malformed stored state
         }


### PR DESCRIPTION
## Summary
- merge stored game state from localStorage with default state values
- ensure team players arrays and nested fields default when missing
- add regression test for initialization merging

## Testing
- `npm run lint`
- `npx vitest run` *(fails: 403 Forbidden fetching vitest)*

------
https://chatgpt.com/codex/tasks/task_e_6893911c73ac832da77a6c25573ac422