### PR TITLE
Guard player maps against undefined arrays

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -59,6 +59,9 @@ export const Dashboard: React.FC<DashboardProps> = ({
   const [homePlayerName, setHomePlayerName] = useState('');
   const [awayPlayerName, setAwayPlayerName] = useState('');
 
+  const homePlayers = gameState.homeTeam.players ?? [];
+  const awayPlayers = gameState.awayTeam.players ?? [];
+
   const handleImageUpload = (team: 'home' | 'away', event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (!file) return;
@@ -403,7 +406,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
                     </button>
                   </div>
                   <ul className="space-y-1 max-h-40 overflow-y-auto">
-                    {gameState.homeTeam.players.map((p) => (
+                    {homePlayers.map((p) => (
                       <li
                         key={p.id}
                         className="flex items-center justify-between text-sm text-gray-700 dark:text-gray-300"
@@ -529,7 +532,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
                     </button>
                   </div>
                   <ul className="space-y-1 max-h-40 overflow-y-auto">
-                    {gameState.awayTeam.players.map((p) => (
+                    {awayPlayers.map((p) => (
                       <li
                         key={p.id}
                         className="flex items-center justify-between text-sm text-gray-700 dark:text-gray-300"

--- a/src/components/StatsTracker.tsx
+++ b/src/components/StatsTracker.tsx
@@ -40,6 +40,8 @@ export const StatsTracker: React.FC<StatsTrackerProps> = ({
   redo,
 }) => {
   const { homeTeam, awayTeam, ballPossession } = gameState;
+  const homePlayers = homeTeam.players ?? [];
+  const awayPlayers = awayTeam.players ?? [];
 
   const totalShotsHome =
     homeTeam.stats.shotsOffTarget + homeTeam.stats.shotsOnTarget;
@@ -125,7 +127,7 @@ export const StatsTracker: React.FC<StatsTrackerProps> = ({
   ) => {
     if (!gameState.isRunning) return;
     const teamObj = team === 'home' ? homeTeam : awayTeam;
-    const player = teamObj.players.find(p => p.id === playerId);
+    const player = (teamObj.players ?? []).find(p => p.id === playerId);
     if (!player) return;
     const newValue = Math.max(0, player[field] + delta);
     updatePlayerStats(team, playerId, field, newValue);
@@ -463,7 +465,7 @@ export const StatsTracker: React.FC<StatsTrackerProps> = ({
                   </tr>
                 </thead>
                 <tbody>
-                  {homeTeam.players.map(p => (
+                  {homePlayers.map(p => (
                     <tr key={p.id} className="text-gray-700 dark:text-gray-300">
                       <td className="py-1">{p.name}</td>
                       <td className="py-1">
@@ -540,7 +542,7 @@ export const StatsTracker: React.FC<StatsTrackerProps> = ({
                   </tr>
                 </thead>
                 <tbody>
-                  {awayTeam.players.map(p => (
+                  {awayPlayers.map(p => (
                     <tr key={p.id} className="text-gray-700 dark:text-gray-300">
                       <td className="py-1">{p.name}</td>
                       <td className="py-1">


### PR DESCRIPTION
## Summary
- default team player arrays to empty before mapping in dashboard and stats tracker
- use fallback when looking up player stats to avoid runtime errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689390fdf068832d99ec1f4a01cd8d4b