### PR TITLE
Limit game state history length

### DIFF
--- a/src/hooks/useGameState.test.ts
+++ b/src/hooks/useGameState.test.ts
@@ -39,6 +39,23 @@ describe('useGameState history', () => {
     result.current.redo();
     expect(result.current.gameState.homeTeam.score).toBe(1);
   });
+
+  it('maintains a maximum of 100 history entries', () => {
+    const { result } = renderHook(() => useGameState());
+
+    for (let i = 1; i <= 110; i++) {
+      result.current.updateTeam('home', 'score', i);
+    }
+
+    for (let i = 0; i < 100; i++) {
+      result.current.undo();
+    }
+
+    expect(result.current.gameState.homeTeam.score).toBe(10);
+
+    result.current.undo();
+    expect(result.current.gameState.homeTeam.score).toBe(10);
+  });
 });
 
 describe('useGameState initialization', () => {

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -86,6 +86,7 @@ const initialState: GameState = {
 };
 
 const STORAGE_KEY = 'gameState';
+const HISTORY_LIMIT = 100;
 
 export const useGameState = () => {
   const [gameState, _setGameState] = useState<GameState>(() => {
@@ -148,6 +149,9 @@ export const useGameState = () => {
             ? (updater as (p: GameState) => GameState)(prev)
             : updater;
         historyRef.current.past.push(prev);
+        if (historyRef.current.past.length > HISTORY_LIMIT) {
+          historyRef.current.past.shift();
+        }
         historyRef.current.future = [];
         return newState;
       });


### PR DESCRIPTION
## Summary
- cap stored game state history at 100 entries
- add regression test to ensure history limit is enforced

## Testing
- `npm run lint`
- `npx vitest run` *(fails: 403 Forbidden when fetching vitest)*

------
https://chatgpt.com/codex/tasks/task_e_6893931c4de0832d8cc0266d62af0166