### PR TITLE
feat: sync remote control with scoreboard

### DIFF
--- a/src/components/RemoteControl.tsx
+++ b/src/components/RemoteControl.tsx
@@ -1,8 +1,54 @@
-import React from 'react';
-import { useGameState } from '../hooks/useGameState';
+import React, { useEffect, useRef, useState } from 'react';
+import type { GameState } from '../types';
 
 export const RemoteControl: React.FC = () => {
-  const { gameState, toggleTimer, updateTeam } = useGameState();
+  const channelRef = useRef<BroadcastChannel | null>(null);
+  const [gameState, setGameState] = useState<GameState | null>(null);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage.getItem('gameState');
+      if (stored) {
+        try {
+          setGameState(JSON.parse(stored) as GameState);
+        } catch {
+          // ignore malformed stored state
+        }
+      }
+    }
+
+    const channel = new BroadcastChannel('game-state');
+    channelRef.current = channel;
+    channel.addEventListener('message', event => {
+      if (event.data?.type === 'STATE_UPDATE') {
+        setGameState(event.data.state as GameState);
+      }
+    });
+
+    return () => {
+      channel.close();
+    };
+  }, []);
+
+  const send = (data: unknown) => {
+    channelRef.current?.postMessage(data);
+  };
+
+  const toggleTimer = () => {
+    send({ type: 'TIMER_CONTROL', action: 'TOGGLE' });
+  };
+
+  const updateTeam = (
+    team: 'home' | 'away',
+    field: 'score' | 'fouls',
+    value: number,
+  ) => {
+    send({ type: 'TEAM_UPDATE', team, field, value });
+  };
+
+  if (!gameState) {
+    return <div className="p-4">Waiting for scoreboard...</div>;
+  }
 
   return (
     <div className="p-4 space-y-8">
@@ -26,7 +72,9 @@ export const RemoteControl: React.FC = () => {
               + Score
             </button>
             <button
-              onClick={() => updateTeam('home', 'score', Math.max(0, gameState.homeTeam.score - 1))}
+              onClick={() =>
+                updateTeam('home', 'score', Math.max(0, gameState.homeTeam.score - 1))
+              }
               className="px-3 py-1 bg-red-500 text-white rounded"
             >
               - Score
@@ -40,7 +88,9 @@ export const RemoteControl: React.FC = () => {
               + Foul
             </button>
             <button
-              onClick={() => updateTeam('home', 'fouls', Math.max(0, gameState.homeTeam.fouls - 1))}
+              onClick={() =>
+                updateTeam('home', 'fouls', Math.max(0, gameState.homeTeam.fouls - 1))
+              }
               className="px-3 py-1 bg-gray-500 text-white rounded"
             >
               - Foul
@@ -58,7 +108,9 @@ export const RemoteControl: React.FC = () => {
               + Score
             </button>
             <button
-              onClick={() => updateTeam('away', 'score', Math.max(0, gameState.awayTeam.score - 1))}
+              onClick={() =>
+                updateTeam('away', 'score', Math.max(0, gameState.awayTeam.score - 1))
+              }
               className="px-3 py-1 bg-red-500 text-white rounded"
             >
               - Score
@@ -72,7 +124,9 @@ export const RemoteControl: React.FC = () => {
               + Foul
             </button>
             <button
-              onClick={() => updateTeam('away', 'fouls', Math.max(0, gameState.awayTeam.fouls - 1))}
+              onClick={() =>
+                updateTeam('away', 'fouls', Math.max(0, gameState.awayTeam.fouls - 1))
+              }
               className="px-3 py-1 bg-gray-500 text-white rounded"
             >
               - Foul

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -139,6 +139,7 @@ export const useGameState = () => {
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const keyboardListenerRef = useRef<((event: KeyboardEvent) => void) | null>(null);
   const skipStorageRef = useRef(false);
+  const channelRef = useRef<BroadcastChannel | null>(null);
 
   const setGameState = useCallback(
     (updater: GameState | ((prev: GameState) => GameState)) => {
@@ -554,47 +555,78 @@ export const useGameState = () => {
     };
   }, [toggleTimer, resetTimer, switchBallPossession, setGameState]);
 
+  const handleRemoteMessage = useCallback(
+    (data: unknown) => {
+      if (typeof data !== 'object' || data === null) {
+        return;
+      }
+
+      const { type } = data as { type?: string };
+
+      switch (type) {
+        case 'TIMER_CONTROL': {
+          const { action } = data as { action?: string };
+          switch (action) {
+            case 'START':
+              setGameState(prev => ({ ...prev, isRunning: true }));
+              break;
+            case 'STOP':
+              setGameState(prev => ({ ...prev, isRunning: false }));
+              break;
+            case 'TOGGLE':
+              toggleTimer();
+              break;
+            case 'RESET':
+              resetTimer();
+              break;
+            default:
+              break;
+          }
+          break;
+        }
+        case 'TEAM_UPDATE': {
+          const { team, field, value } = data as {
+            team?: 'home' | 'away';
+            field?: keyof Pick<Team, 'name' | 'score' | 'fouls' | 'logo'>;
+            value?: string | number;
+          };
+          if (team === 'home' || team === 'away') {
+            if (field) {
+              updateTeam(team, field, value as Team[keyof Team]);
+            }
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    },
+    [toggleTimer, resetTimer, setGameState, updateTeam],
+  );
+
   // API endpoint simulation for external control
   useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
+    const windowHandler = (event: MessageEvent) => {
       if (event.origin !== window.location.origin) return;
-
-      if (typeof event.data !== 'object' || event.data === null) {
-        return;
-      }
-
-      if (!('type' in event.data) || !('action' in event.data)) {
-        return;
-      }
-
-      const { type, action } = event.data as { type: unknown; action: unknown };
-
-      if (type !== 'TIMER_CONTROL' || typeof action !== 'string') {
-        return;
-      }
-
-      switch (action) {
-        case 'START':
-          setGameState(prev => ({ ...prev, isRunning: true }));
-          break;
-        case 'STOP':
-          setGameState(prev => ({ ...prev, isRunning: false }));
-          break;
-        case 'TOGGLE':
-          toggleTimer();
-          break;
-        case 'RESET':
-          resetTimer();
-          break;
-        default:
-          // Ignore unknown actions
-          break;
-      }
+      handleRemoteMessage(event.data);
     };
 
-    window.addEventListener('message', handleMessage);
-    return () => window.removeEventListener('message', handleMessage);
-  }, [toggleTimer, resetTimer, setGameState]);
+    window.addEventListener('message', windowHandler);
+    let channel: BroadcastChannel | null = null;
+    if (typeof BroadcastChannel !== 'undefined') {
+      channel = new BroadcastChannel('game-state');
+      channel.addEventListener('message', e => handleRemoteMessage(e.data));
+      channelRef.current = channel;
+    }
+    return () => {
+      window.removeEventListener('message', windowHandler);
+      channel?.close();
+    };
+  }, [handleRemoteMessage]);
+
+  useEffect(() => {
+    channelRef.current?.postMessage({ type: 'STATE_UPDATE', state: gameState });
+  }, [gameState]);
 
   useEffect(() => {
     if (gameState.isRunning) {


### PR DESCRIPTION
## Summary
- use BroadcastChannel for remote control actions
- handle remote timer and team updates in game state hook

## Testing
- `npm run lint`
- `npx vitest run` *(fails: 403 Forbidden to fetch vitest)*


------
https://chatgpt.com/codex/tasks/task_e_6893936bee30832d916e16d7a595e681