### PR TITLE
Guard window pathname check

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ function App() {
     setViewMode(view);
   };
 
-  if (window.location.pathname === '/remote') {
+  if (typeof window !== 'undefined' && window.location.pathname === '/remote') {
     return <RemoteControl />;
   }
 


### PR DESCRIPTION
## Summary
- Avoid referencing window outside the browser by guarding pathname check in `App`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68939371c5b0832d86875449da2f8555