### PR TITLE
Clear history on reset

### DIFF
--- a/src/hooks/useGameState.test.ts
+++ b/src/hooks/useGameState.test.ts
@@ -56,6 +56,22 @@ describe('useGameState history', () => {
     result.current.undo();
     expect(result.current.gameState.homeTeam.score).toBe(10);
   });
+
+  it('clears history after a game reset', () => {
+    const { result } = renderHook(() => useGameState());
+
+    result.current.updateTeam('home', 'score', 1);
+    expect(result.current.gameState.homeTeam.score).toBe(1);
+
+    result.current.resetGame();
+    expect(result.current.gameState.homeTeam.score).toBe(0);
+
+    result.current.undo();
+    expect(result.current.gameState.homeTeam.score).toBe(0);
+
+    result.current.redo();
+    expect(result.current.gameState.homeTeam.score).toBe(0);
+  });
 });
 
 describe('useGameState initialization', () => {

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -467,7 +467,9 @@ export const useGameState = () => {
     if (typeof window !== 'undefined') {
       window.localStorage.removeItem(STORAGE_KEY);
     }
-    setGameState(prev => {
+    historyRef.current.past = [];
+    historyRef.current.future = [];
+    _setGameState(prev => {
       const base = {
         ...initialState,
         gamePreset: prev.gamePreset, // Keep current preset
@@ -481,7 +483,7 @@ export const useGameState = () => {
         awayTeam: adjustTeamStatsForType(base.awayTeam, prev.gamePreset.type),
       };
     });
-  }, [setGameState]);
+  }, []);
 
   const undo = useCallback(() => {
     _setGameState(prev => {


### PR DESCRIPTION
## Summary
- clear undo/redo history when resetting the game state
- cover reset behavior with additional test

## Testing
- `npm run lint`
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_689399a878d4832dbbdeb83c8ad83ece