### PR TITLE
Adjust team score and stats when removing player

### DIFF
--- a/src/hooks/useGameState.test.ts
+++ b/src/hooks/useGameState.test.ts
@@ -80,3 +80,28 @@ describe('useGameState initialization', () => {
   });
 });
 
+describe('useGameState player management', () => {
+  it('removes player and adjusts team totals', () => {
+    const { result } = renderHook(() => useGameState());
+
+    result.current.addPlayer('home', 'Test Player');
+    const playerId = result.current.gameState.homeTeam.players[0].id;
+
+    result.current.updatePlayerStats('home', playerId, 'goals', 2);
+    result.current.updatePlayerStats('home', playerId, 'yellowCards', 1);
+    result.current.updatePlayerStats('home', playerId, 'redCards', 1);
+
+    result.current.toggleTimer();
+    result.current.updateTeamStats('home', 'yellowCards', 1);
+    result.current.updateTeamStats('home', 'redCards', 1);
+    result.current.toggleTimer();
+
+    result.current.removePlayer('home', playerId);
+
+    expect(result.current.gameState.homeTeam.score).toBe(0);
+    expect(result.current.gameState.homeTeam.stats.yellowCards).toBe(0);
+    expect(result.current.gameState.homeTeam.stats.redCards).toBe(0);
+    expect(result.current.gameState.homeTeam.players).toHaveLength(0);
+  });
+});
+

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -226,15 +226,34 @@ export const useGameState = () => {
 
   const removePlayer = useCallback(
     (team: 'home' | 'away', playerId: string) => {
-      setGameState(prev => ({
-        ...prev,
-        [team === 'home' ? 'homeTeam' : 'awayTeam']: {
-          ...prev[team === 'home' ? 'homeTeam' : 'awayTeam'],
-          players: prev[team === 'home' ? 'homeTeam' : 'awayTeam'].players.filter(
-            p => p.id !== playerId,
-          ),
-        },
-      }));
+      setGameState(prev => {
+        const teamKey = team === 'home' ? 'homeTeam' : 'awayTeam';
+        const teamObj = prev[teamKey];
+        const playerToRemove = teamObj.players.find(p => p.id === playerId);
+        if (!playerToRemove) return prev;
+
+        const updatedTeam: Team = {
+          ...teamObj,
+          score: Math.max(0, teamObj.score - playerToRemove.goals),
+          stats: {
+            ...teamObj.stats,
+            yellowCards: Math.max(
+              0,
+              teamObj.stats.yellowCards - playerToRemove.yellowCards,
+            ),
+            redCards: Math.max(
+              0,
+              teamObj.stats.redCards - playerToRemove.redCards,
+            ),
+          },
+          players: teamObj.players.filter(p => p.id !== playerId),
+        };
+
+        return {
+          ...prev,
+          [teamKey]: updatedTeam,
+        };
+      });
     },
     [setGameState],
   );


### PR DESCRIPTION
## Summary
- adjust removePlayer to subtract a player's goals and cards from team totals before updating roster
- add test ensuring player removal adjusts team score and card counts

## Testing
- `npx vitest run --environment jsdom` *(fails: missing vitest package)*
- `npm install --save-dev vitest @testing-library/react` *(fails: 403 Forbidden)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689399aad9e4832d9bdfaa9158ed808a