### PR TITLE
Prevent timer underflow

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -114,6 +114,9 @@ export const Dashboard: React.FC<DashboardProps> = ({
 
   const adjustTime = (type: 'minutes' | 'seconds', delta: number) => {
     const { minutes, seconds } = gameState.time;
+    if (minutes === 0 && seconds === 0 && delta < 0) {
+      return;
+    }
     if (type === 'minutes') {
       const newMinutes = Math.max(0, Math.min(60, minutes + delta));
       updateTime(newMinutes, seconds);


### PR DESCRIPTION
## Summary
- guard timer against negative adjustments when already at 00:00

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68939b823814832dae4bcb4162b4cc59