### PR TITLE
Clamp timer values in useGameState hook

### DIFF
--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -318,9 +318,11 @@ export const useGameState = () => {
     });
   }, [setGameState]);
   const updateTime = useCallback((minutes: number, seconds: number) => {
+    const clampedMinutes = Math.max(0, Math.floor(minutes));
+    const clampedSeconds = Math.max(0, Math.min(59, Math.floor(seconds)));
     setGameState(prev => ({
       ...prev,
-      time: { minutes, seconds },
+      time: { minutes: clampedMinutes, seconds: clampedSeconds },
     }));
   }, [setGameState]);
 


### PR DESCRIPTION
## Summary
- ensure timer values are clamped to valid ranges before updating state

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68939b82954c832db4554c6c3dea1f75