### PR TITLE
Limit history growth on redo

### DIFF
--- a/src/hooks/useGameState.test.ts
+++ b/src/hooks/useGameState.test.ts
@@ -47,6 +47,14 @@ describe('useGameState history', () => {
       result.current.updateTeam('home', 'score', i);
     }
 
+    for (let i = 0; i < 50; i++) {
+      result.current.undo();
+    }
+
+    for (let i = 0; i < 60; i++) {
+      result.current.redo();
+    }
+
     for (let i = 0; i < 100; i++) {
       result.current.undo();
     }

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -520,6 +520,9 @@ export const useGameState = () => {
       if (future.length === 0) return prev;
       const next = future.pop() as GameState;
       historyRef.current.past.push(prev);
+      if (historyRef.current.past.length > HISTORY_LIMIT) {
+        historyRef.current.past.shift();
+      }
       return next;
     });
   }, []);


### PR DESCRIPTION
## Summary
- prevent redo from exceeding history limit by trimming oldest entries
- exercise undo/redo sequence in history limit test

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68939b85fdac832da6822f5c7959a538