### PR TITLE
Respect match phase time limits

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -144,24 +144,40 @@ export const Dashboard: React.FC<DashboardProps> = ({
 
   const adjustTime = (type: 'minutes' | 'seconds', delta: number) => {
     const { minutes, seconds } = gameState.time;
+    const maxMinutes =
+      gameState.matchPhase === 'regular'
+        ? gameState.gamePreset.halfDuration
+        : gameState.matchPhase === 'extra-time'
+        ? gameState.gamePreset.extraTimeDuration
+        : 0;
+    if (maxMinutes === 0) {
+      return;
+    }
     if (minutes === 0 && seconds === 0 && delta < 0) {
       return;
     }
     if (type === 'minutes') {
-      const newMinutes = Math.max(0, Math.min(60, minutes + delta));
+      const newMinutes = Math.max(0, Math.min(maxMinutes, minutes + delta));
       updateTime(newMinutes, seconds);
     } else {
       let newSeconds = seconds + delta;
       let newMinutes = minutes;
-      
+
       if (newSeconds >= 60) {
         newSeconds = 0;
-        newMinutes = Math.min(60, minutes + 1);
+        newMinutes = Math.min(maxMinutes, minutes + 1);
       } else if (newSeconds < 0) {
         newSeconds = 59;
         newMinutes = Math.max(0, minutes - 1);
       }
-      
+
+      if (newMinutes >= maxMinutes) {
+        newMinutes = maxMinutes;
+        if (newSeconds > 0) {
+          newSeconds = 0;
+        }
+      }
+
       updateTime(newMinutes, newSeconds);
     }
   };

--- a/src/hooks/useGameState.test.ts
+++ b/src/hooks/useGameState.test.ts
@@ -129,3 +129,50 @@ describe('useGameState player management', () => {
   });
 });
 
+describe('useGameState time limits', () => {
+  it('clamps time to half duration in regular phase', () => {
+    const { result } = renderHook(() => useGameState());
+    result.current.updateTime(999, 30);
+    expect(result.current.gameState.time.minutes).toBe(
+      result.current.gameState.gamePreset.halfDuration
+    );
+    expect(result.current.gameState.time.seconds).toBe(0);
+  });
+
+  it('clamps time to extra-time duration in extra-time phase', () => {
+    const { result } = renderHook(() => useGameState());
+    result.current.changeGamePreset(1); // preset with extra time and penalties
+    result.current.updatePeriod(3); // switch to extra-time
+    result.current.updateTime(999, 30);
+    expect(result.current.gameState.matchPhase).toBe('extra-time');
+    expect(result.current.gameState.time.minutes).toBe(
+      result.current.gameState.gamePreset.extraTimeDuration
+    );
+    expect(result.current.gameState.time.seconds).toBe(0);
+  });
+
+  it('keeps timer at zero during penalties', () => {
+    const { result } = renderHook(() => useGameState());
+    result.current.changeGamePreset(1);
+    result.current.updatePeriod(5); // switch to penalties
+    result.current.updateTime(5, 30);
+    expect(result.current.gameState.matchPhase).toBe('penalties');
+    expect(result.current.gameState.time.minutes).toBe(0);
+    expect(result.current.gameState.time.seconds).toBe(0);
+  });
+
+  it('resetTimer respects current phase duration', () => {
+    const { result } = renderHook(() => useGameState());
+    result.current.changeGamePreset(1);
+    result.current.updatePeriod(3);
+    result.current.resetTimer();
+    expect(result.current.gameState.time.minutes).toBe(
+      result.current.gameState.gamePreset.extraTimeDuration
+    );
+    result.current.updatePeriod(5);
+    result.current.resetTimer();
+    expect(result.current.gameState.time.minutes).toBe(0);
+    expect(result.current.gameState.time.seconds).toBe(0);
+  });
+});
+

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -318,12 +318,23 @@ export const useGameState = () => {
     });
   }, [setGameState]);
   const updateTime = useCallback((minutes: number, seconds: number) => {
-    const clampedMinutes = Math.max(0, Math.floor(minutes));
-    const clampedSeconds = Math.max(0, Math.min(59, Math.floor(seconds)));
-    setGameState(prev => ({
-      ...prev,
-      time: { minutes: clampedMinutes, seconds: clampedSeconds },
-    }));
+    setGameState(prev => {
+      const maxMinutes =
+        prev.matchPhase === 'regular'
+          ? prev.gamePreset.halfDuration
+          : prev.matchPhase === 'extra-time'
+          ? prev.gamePreset.extraTimeDuration
+          : 0;
+      const clampedMinutes = Math.max(0, Math.min(maxMinutes, Math.floor(minutes)));
+      let clampedSeconds = Math.max(0, Math.min(59, Math.floor(seconds)));
+      if (clampedMinutes === maxMinutes && clampedSeconds > 0) {
+        clampedSeconds = 0;
+      }
+      return {
+        ...prev,
+        time: { minutes: clampedMinutes, seconds: clampedSeconds },
+      };
+    });
   }, [setGameState]);
 
   const toggleTimer = useCallback(() => {
@@ -362,9 +373,15 @@ export const useGameState = () => {
               homePossession: prev.homeTeam.stats.possession,
               awayPossession: prev.awayTeam.stats.possession,
             };
+      const maxMinutes =
+        prev.matchPhase === 'regular'
+          ? prev.gamePreset.halfDuration
+          : prev.matchPhase === 'extra-time'
+          ? prev.gamePreset.extraTimeDuration
+          : 0;
       return {
         ...prev,
-        time: { minutes: prev.gamePreset.halfDuration, seconds: 0 },
+        time: { minutes: maxMinutes, seconds: 0 },
         isRunning: false,
         possessionStartTime: now,
         totalPossessionTime: updatedPossessionTime,


### PR DESCRIPTION
## Summary
- Clamp timer updates to match phase durations and reset accordingly
- Limit manual time adjustments to phase-specific maximums
- Add tests verifying time limits for regular, extra-time, and penalties

## Testing
- `npm run lint`
- `npm run build`
- `npx vitest run` *(fails: 403 Forbidden fetching vitest)*
- `npm install --save-dev vitest @testing-library/react` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68939f5bfd44832dbd404f97e4d48f11