### PR TITLE
feat: add confirmation modal for game reset

### DIFF
--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+interface ConfirmModalProps {
+  isOpen: boolean;
+  title?: string;
+  message: string;
+  confirmText?: string;
+  cancelText?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export const ConfirmModal: React.FC<ConfirmModalProps> = ({
+  isOpen,
+  title = 'Confirm',
+  message,
+  confirmText = 'Confirm',
+  cancelText = 'Cancel',
+  onConfirm,
+  onCancel,
+}) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6 max-w-sm w-full">
+        {title && (
+          <h2 className="text-lg font-semibold mb-4 text-gray-900 dark:text-gray-100">
+            {title}
+          </h2>
+        )}
+        <p className="text-gray-700 dark:text-gray-300 mb-6">{message}</p>
+        <div className="flex justify-end gap-4">
+          <button
+            onClick={onCancel}
+            className="px-4 py-2 bg-gray-200 text-gray-800 rounded hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+          >
+            {cancelText}
+          </button>
+          <button
+            onClick={onConfirm}
+            className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
+          >
+            {confirmText}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmModal;

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -3,6 +3,7 @@ import { GameState } from '../types';
 import { ExternalControlInfo } from './ExternalControlInfo';
 import { GamePresetSelector } from './GamePresetSelector';
 import { getHalfName } from '../utils/gamePresets';
+import { ConfirmModal } from './ConfirmModal';
 import {
   Play,
   Pause,
@@ -58,6 +59,8 @@ export const Dashboard: React.FC<DashboardProps> = ({
   const [tournamentLogoError, setTournamentLogoError] = useState('');
   const [homePlayerName, setHomePlayerName] = useState('');
   const [awayPlayerName, setAwayPlayerName] = useState('');
+
+  const [showResetConfirm, setShowResetConfirm] = useState(false);
 
   const homeLogoUrlRef = useRef<string | null>(null);
   const awayLogoUrlRef = useRef<string | null>(null);
@@ -182,9 +185,20 @@ export const Dashboard: React.FC<DashboardProps> = ({
       Object.values(gameState.homeTeam.stats).some(v => v !== 0) ||
       Object.values(gameState.awayTeam.stats).some(v => v !== 0);
 
-    if (!hasStarted || window.confirm('Are you sure you want to reset the entire game?')) {
+    if (!hasStarted) {
       resetGame({ force: true });
+    } else {
+      setShowResetConfirm(true);
     }
+  };
+
+  const confirmResetGame = () => {
+    resetGame({ force: true });
+    setShowResetConfirm(false);
+  };
+
+  const cancelResetGame = () => {
+    setShowResetConfirm(false);
   };
 
   return (
@@ -743,6 +757,15 @@ export const Dashboard: React.FC<DashboardProps> = ({
           </div>
         )}
       </div>
+      <ConfirmModal
+        isOpen={showResetConfirm}
+        title="Reset Game"
+        message="Are you sure you want to reset the entire game?"
+        confirmText="Reset"
+        cancelText="Cancel"
+        onConfirm={confirmResetGame}
+        onCancel={cancelResetGame}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add reusable `ConfirmModal` component for flexible confirmation dialogs
- replace `window.confirm` with modal-driven state in dashboard reset flow

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893a8115c38832d9f637222be17c9e8