### PR TITLE
feat: add standalone settings page and routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,8 @@ import { PossessionTracker } from './components/PossessionTracker';
 import { ControlPanelButton } from './components/ControlPanelButton';
 import { ThemeToggle } from './components/ThemeToggle';
 import { RemoteControl } from './components/RemoteControl';
+import { SettingsPage } from './components/SettingsPage';
+import { LayoutDashboard } from 'lucide-react';
 
 type ViewMode = 'scoreboard' | 'dashboard' | 'overlay' | 'stats' | 'possession';
 
@@ -34,14 +36,46 @@ function App() {
     return <RemoteControl />;
   }
 
+  if (route === '#/settings') {
+    return (
+      <div className="App">
+        <ThemeToggle theme={theme} onToggle={toggleTheme} />
+        <SettingsPage
+          gameState={gameState.gameState}
+          updateTeam={gameState.updateTeam}
+          resetGame={gameState.resetGame}
+        />
+        <ControlPanelButton
+          icon={LayoutDashboard}
+          ariaLabel="Open control panel"
+          onClick={() => {
+            window.location.hash = '';
+            setViewMode('dashboard');
+          }}
+        />
+      </div>
+    );
+  }
+
   return (
     <div className="App">
       <ThemeToggle theme={theme} onToggle={toggleTheme} />
       {viewMode === 'overlay' ? (
         <div className="relative min-h-screen bg-transparent">
           <Overlay gameState={gameState.gameState} />
-          {/* Floating control button */}
-          <ControlPanelButton onClick={() => setViewMode('dashboard')} />
+          {/* Floating buttons */}
+          <ControlPanelButton
+            icon={LayoutDashboard}
+            ariaLabel="Open control panel"
+            className="right-36"
+            onClick={() => setViewMode('dashboard')}
+          />
+          <ControlPanelButton
+            ariaLabel="Open settings"
+            onClick={() => {
+              window.location.hash = '#/settings';
+            }}
+          />
         </div>
       ) : viewMode === 'stats' ? (
         <div className="relative">
@@ -55,14 +89,36 @@ function App() {
             undo={gameState.undo}
             redo={gameState.redo}
           />
-          {/* Floating control button */}
-          <ControlPanelButton onClick={() => setViewMode('dashboard')} />
+          {/* Floating buttons */}
+          <ControlPanelButton
+            icon={LayoutDashboard}
+            ariaLabel="Open control panel"
+            className="right-36"
+            onClick={() => setViewMode('dashboard')}
+          />
+          <ControlPanelButton
+            ariaLabel="Open settings"
+            onClick={() => {
+              window.location.hash = '#/settings';
+            }}
+          />
         </div>
       ) : viewMode === 'scoreboard' ? (
         <div className="relative">
           <Scoreboard gameState={gameState.gameState} />
-          {/* Floating control button */}
-          <ControlPanelButton onClick={() => setViewMode('dashboard')} />
+          {/* Floating buttons */}
+          <ControlPanelButton
+            icon={LayoutDashboard}
+            ariaLabel="Open control panel"
+            className="right-36"
+            onClick={() => setViewMode('dashboard')}
+          />
+          <ControlPanelButton
+            ariaLabel="Open settings"
+            onClick={() => {
+              window.location.hash = '#/settings';
+            }}
+          />
         </div>
       ) : viewMode === 'possession' ? (
         <div className="relative">
@@ -70,26 +126,44 @@ function App() {
             gameState={gameState.gameState}
             switchBallPossession={gameState.switchBallPossession}
           />
-          {/* Floating control button */}
-          <ControlPanelButton onClick={() => setViewMode('dashboard')} />
+          {/* Floating buttons */}
+          <ControlPanelButton
+            icon={LayoutDashboard}
+            ariaLabel="Open control panel"
+            className="right-36"
+            onClick={() => setViewMode('dashboard')}
+          />
+          <ControlPanelButton
+            ariaLabel="Open settings"
+            onClick={() => {
+              window.location.hash = '#/settings';
+            }}
+          />
         </div>
       ) : (
-        <Dashboard
-          gameState={gameState.gameState}
-          updateTeam={gameState.updateTeam}
-          updateTournamentLogo={gameState.updateTournamentLogo}
-          updateTime={gameState.updateTime}
-          toggleTimer={gameState.toggleTimer}
-          resetTimer={gameState.resetTimer}
-          updatePeriod={gameState.updatePeriod}
-          changeGamePreset={gameState.changeGamePreset}
-          resetGame={gameState.resetGame}
-          undo={gameState.undo}
-          redo={gameState.redo}
-          addPlayer={gameState.addPlayer}
-          removePlayer={gameState.removePlayer}
-          onViewChange={handleViewChange}
-        />
+        <>
+          <Dashboard
+            gameState={gameState.gameState}
+            updateTeam={gameState.updateTeam}
+            updateTournamentLogo={gameState.updateTournamentLogo}
+            updateTime={gameState.updateTime}
+            toggleTimer={gameState.toggleTimer}
+            resetTimer={gameState.resetTimer}
+            updatePeriod={gameState.updatePeriod}
+            changeGamePreset={gameState.changeGamePreset}
+            undo={gameState.undo}
+            redo={gameState.redo}
+            addPlayer={gameState.addPlayer}
+            removePlayer={gameState.removePlayer}
+            onViewChange={handleViewChange}
+          />
+          <ControlPanelButton
+            ariaLabel="Open settings"
+            onClick={() => {
+              window.location.hash = '#/settings';
+            }}
+          />
+        </>
       )}
     </div>
   );

--- a/src/components/ControlPanelButton.tsx
+++ b/src/components/ControlPanelButton.tsx
@@ -1,18 +1,35 @@
 import React from 'react';
-import { Settings } from 'lucide-react';
+import { Settings, type LucideIcon } from 'lucide-react';
 
 interface ControlPanelButtonProps {
   onClick: () => void;
+  /**
+   * Optional icon to display inside the button. Defaults to a settings icon.
+   */
+  icon?: LucideIcon;
+  /**
+   * Accessible label for the button. Defaults to "Open control panel".
+   */
+  ariaLabel?: string;
+  /**
+   * Additional tailwind classes for positioning. Defaults to `right-20`.
+   */
+  className?: string;
 }
 
-// Floating action button with an icon for a more modern feel
-export const ControlPanelButton: React.FC<ControlPanelButtonProps> = ({ onClick }) => (
+// Floating action button with a customizable icon for navigation
+export const ControlPanelButton: React.FC<ControlPanelButtonProps> = ({
+  onClick,
+  icon: Icon = Settings,
+  ariaLabel = 'Open control panel',
+  className,
+}) => (
   <button
     onClick={onClick}
-    aria-label="Open control panel"
-    className="fixed top-5 right-20 w-12 h-12 rounded-full bg-indigo-600/80 text-white flex items-center justify-center shadow-lg hover:bg-indigo-600 backdrop-blur-md transition-colors z-50"
+    aria-label={ariaLabel}
+    className={`fixed top-5 w-12 h-12 rounded-full bg-indigo-600/80 text-white flex items-center justify-center shadow-lg hover:bg-indigo-600 backdrop-blur-md transition-colors z-50 ${className ?? 'right-20'}`}
   >
-    <Settings className="w-5 h-5" />
+    <Icon className="w-5 h-5" />
   </button>
 );
 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,21 +1,8 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { GameState } from '../types';
-import { ExternalControlInfo } from './ExternalControlInfo';
 import { GamePresetSelector } from './GamePresetSelector';
 import { getHalfName } from '../utils/gamePresets';
-import {
-  Play,
-  Pause,
-  RotateCcw,
-  Plus,
-  Minus,
-  Upload,
-  Monitor,
-  BarChart3,
-  Timer,
-  Undo2,
-  Redo2,
-} from 'lucide-react';
+import { Play, Pause, Plus, Minus, Upload, Monitor, BarChart3, Timer, Undo2, Redo2 } from 'lucide-react';
 
 interface DashboardProps {
   gameState: GameState;
@@ -26,7 +13,6 @@ interface DashboardProps {
   resetTimer: () => void;
   updatePeriod: (period: number) => void;
   changeGamePreset: (presetIndex: number) => void;
-  resetGame: (options?: { force?: boolean }) => void;
   undo: () => void;
   redo: () => void;
   addPlayer: (team: 'home' | 'away', name: string) => void;
@@ -43,15 +29,14 @@ export const Dashboard: React.FC<DashboardProps> = ({
   resetTimer,
   updatePeriod,
   changeGamePreset,
-  resetGame,
   undo,
   redo,
   addPlayer,
   removePlayer,
   onViewChange,
 }) => {
-  const [activeTab, setActiveTab] = useState<'teams' | 'timer' | 'format' | 'settings'>('teams');
-  const tabs = ['teams', 'timer', 'format', 'settings'] as const;
+const [activeTab, setActiveTab] = useState<'teams' | 'timer' | 'format'>('teams');
+const tabs = ['teams', 'timer', 'format'] as const;
 
   const [homeLogoError, setHomeLogoError] = useState('');
   const [awayLogoError, setAwayLogoError] = useState('');
@@ -167,23 +152,6 @@ export const Dashboard: React.FC<DashboardProps> = ({
       }
 
       updateTime(newMinutes, newSeconds);
-    }
-  };
-
-  const handleResetGame = () => {
-    const hasStarted =
-      gameState.isRunning ||
-      gameState.time.minutes !== gameState.gamePreset.halfDuration ||
-      gameState.time.seconds !== 0 ||
-      gameState.homeTeam.score !== 0 ||
-      gameState.awayTeam.score !== 0 ||
-      gameState.homeTeam.fouls !== 0 ||
-      gameState.awayTeam.fouls !== 0 ||
-      Object.values(gameState.homeTeam.stats).some(v => v !== 0) ||
-      Object.values(gameState.awayTeam.stats).some(v => v !== 0);
-
-    if (!hasStarted || window.confirm('Are you sure you want to reset the entire game?')) {
-      resetGame({ force: true });
     }
   };
 
@@ -694,54 +662,6 @@ export const Dashboard: React.FC<DashboardProps> = ({
           />
         )}
 
-        {/* Settings Tab */}
-        {activeTab === 'settings' && (
-          <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-8 max-w-2xl mx-auto">
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-8 text-center">Game Settings</h3>
-            
-            <div className="space-y-8">
-              {/* External Control Info */}
-              <ExternalControlInfo />
-
-              <div className="text-center">
-                <button
-                  onClick={handleResetGame}
-                  className="inline-flex items-center gap-2 px-6 py-3 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors font-semibold"
-                >
-                  <RotateCcw className="w-5 h-5" />
-                  Reset Entire Game
-                </button>
-                <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
-                  This will reset scores, fouls, timer, and all settings to default values.
-                </p>
-              </div>
-
-              <div className="border-t pt-6">
-                <h4 className="font-semibold text-gray-900 dark:text-gray-100 mb-4">Quick Actions</h4>
-                <div className="grid grid-cols-2 gap-4">
-                  <button
-                    onClick={() => {
-                      updateTeam('home', 'score', 0);
-                      updateTeam('away', 'score', 0);
-                    }}
-                    className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
-                  >
-                    Reset Scores
-                  </button>
-                  <button
-                    onClick={() => {
-                      updateTeam('home', 'fouls', 0);
-                      updateTeam('away', 'fouls', 0);
-                    }}
-                    className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
-                  >
-                    Reset Fouls
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
       </div>
     </div>
   );

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { RotateCcw } from 'lucide-react';
+import { ExternalControlInfo } from './ExternalControlInfo';
+import { GameState } from '../types';
+
+interface SettingsPageProps {
+  gameState: GameState;
+  updateTeam: (
+    team: 'home' | 'away',
+    field: 'name' | 'score' | 'fouls' | 'logo',
+    value: string | number
+  ) => void;
+  resetGame: (options?: { force?: boolean }) => void;
+}
+
+export const SettingsPage: React.FC<SettingsPageProps> = ({
+  gameState,
+  updateTeam,
+  resetGame,
+}) => {
+  const handleResetGame = () => {
+    const hasStarted =
+      gameState.isRunning ||
+      gameState.time.minutes !== gameState.gamePreset.halfDuration ||
+      gameState.time.seconds !== 0 ||
+      gameState.homeTeam.score !== 0 ||
+      gameState.awayTeam.score !== 0 ||
+      gameState.homeTeam.fouls !== 0 ||
+      gameState.awayTeam.fouls !== 0 ||
+      Object.values(gameState.homeTeam.stats).some(v => v !== 0) ||
+      Object.values(gameState.awayTeam.stats).some(v => v !== 0);
+
+    if (!hasStarted || window.confirm('Are you sure you want to reset the entire game?')) {
+      resetGame({ force: true });
+    }
+  };
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-8 max-w-2xl mx-auto mt-24">
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-8 text-center">
+        Game Settings
+      </h3>
+
+      <div className="space-y-8">
+        {/* External Control Info */}
+        <ExternalControlInfo />
+
+        <div className="text-center">
+          <button
+            onClick={handleResetGame}
+            className="inline-flex items-center gap-2 px-6 py-3 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors font-semibold"
+          >
+            <RotateCcw className="w-5 h-5" />
+            Reset Entire Game
+          </button>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
+            This will reset scores, fouls, timer, and all settings to default values.
+          </p>
+        </div>
+
+        <div className="border-t pt-6">
+          <h4 className="font-semibold text-gray-900 dark:text-gray-100 mb-4">
+            Quick Actions
+          </h4>
+          <div className="grid grid-cols-2 gap-4">
+            <button
+              onClick={() => {
+                updateTeam('home', 'score', 0);
+                updateTeam('away', 'score', 0);
+              }}
+              className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+            >
+              Reset Scores
+            </button>
+            <button
+              onClick={() => {
+                updateTeam('home', 'fouls', 0);
+                updateTeam('away', 'fouls', 0);
+              }}
+              className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+            >
+              Reset Fouls
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+


### PR DESCRIPTION
## Summary
- extract settings tab into standalone `SettingsPage`
- add `/settings` route and floating buttons to navigate there from any view
- make `ControlPanelButton` customizable for various navigation targets

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6893a81d4458832dae2fa62124d26a9e