### PR TITLE
Add undo/redo visibility toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,6 +86,7 @@ function App() {
           resetGame={gameState.resetGame}
           undo={gameState.undo}
           redo={gameState.redo}
+          setShowUndoRedo={gameState.setShowUndoRedo}
           addPlayer={gameState.addPlayer}
           removePlayer={gameState.removePlayer}
           onViewChange={handleViewChange}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -29,6 +29,7 @@ interface DashboardProps {
   resetGame: (options?: { force?: boolean }) => void;
   undo: () => void;
   redo: () => void;
+  setShowUndoRedo: (value: boolean) => void;
   addPlayer: (team: 'home' | 'away', name: string) => void;
   removePlayer: (team: 'home' | 'away', playerId: string) => void;
   onViewChange: (view: 'scoreboard' | 'dashboard' | 'overlay' | 'stats' | 'possession') => void;
@@ -46,6 +47,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
   resetGame,
   undo,
   redo,
+  setShowUndoRedo,
   addPlayer,
   removePlayer,
   onViewChange,
@@ -223,20 +225,24 @@ export const Dashboard: React.FC<DashboardProps> = ({
                 <Timer className="w-4 h-4" />
                 Possession Control
               </button>
-              <button
-                onClick={undo}
-                className="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 transition-colors"
-              >
-                <Undo2 className="w-4 h-4" />
-                Undo
-              </button>
-              <button
-                onClick={redo}
-                className="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 transition-colors"
-              >
-                <Redo2 className="w-4 h-4" />
-                Redo
-              </button>
+              {gameState.showUndoRedo && (
+                <>
+                  <button
+                    onClick={undo}
+                    className="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 transition-colors"
+                  >
+                    <Undo2 className="w-4 h-4" />
+                    Undo
+                  </button>
+                  <button
+                    onClick={redo}
+                    className="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 transition-colors"
+                  >
+                    <Redo2 className="w-4 h-4" />
+                    Redo
+                  </button>
+                </>
+              )}
             </div>
           </div>
         </div>
@@ -698,10 +704,23 @@ export const Dashboard: React.FC<DashboardProps> = ({
         {activeTab === 'settings' && (
           <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-8 max-w-2xl mx-auto">
             <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-8 text-center">Game Settings</h3>
-            
+
             <div className="space-y-8">
               {/* External Control Info */}
               <ExternalControlInfo />
+
+              <div className="flex items-center justify-between">
+                <span className="text-gray-700 dark:text-gray-300">Show Undo/Redo Buttons</span>
+                <label className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    className="w-5 h-5"
+                    checked={gameState.showUndoRedo}
+                    onChange={e => setShowUndoRedo(e.target.checked)}
+                  />
+                  <span>{gameState.showUndoRedo ? 'On' : 'Off'}</span>
+                </label>
+              </div>
 
               <div className="text-center">
                 <button

--- a/src/components/StatsTracker.tsx
+++ b/src/components/StatsTracker.tsx
@@ -242,24 +242,25 @@ export const StatsTracker: React.FC<StatsTrackerProps> = ({
           <div className="flex justify-between items-center py-4">
             <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Match Statistics Tracker</h1>
             <div className="flex items-center gap-4">
-              <div className="flex items-center gap-6 text-sm text-gray-600 dark:text-gray-400">
-                <div>
-                  {homeTeam.name} vs {awayTeam.name}
-                </div>
-                <div className="flex items-center gap-2">
-                  <Timer className="w-4 h-4" />
-                  <span>{formatTime(gameState.time.minutes, gameState.time.seconds)}</span>
-                </div>
-                <div
-                  className={`px-2 py-1 rounded-full font-medium ${
-                    gameState.isRunning
-                      ? 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300'
-                      : 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300'
-                  }`}
-                >
-                  {gameState.isRunning ? 'Live' : 'Paused'}
-                </div>
+            <div className="flex items-center gap-6 text-sm text-gray-600 dark:text-gray-400">
+              <div>
+                {homeTeam.name} vs {awayTeam.name}
               </div>
+              <div className="flex items-center gap-2">
+                <Timer className="w-4 h-4" />
+                <span>{formatTime(gameState.time.minutes, gameState.time.seconds)}</span>
+              </div>
+              <div
+                className={`px-2 py-1 rounded-full font-medium ${
+                  gameState.isRunning
+                    ? 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300'
+                    : 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300'
+                }`}
+              >
+                {gameState.isRunning ? 'Live' : 'Paused'}
+              </div>
+            </div>
+            {gameState.showUndoRedo && (
               <div className="flex gap-2">
                 <button
                   onClick={undo}
@@ -274,9 +275,10 @@ export const StatsTracker: React.FC<StatsTrackerProps> = ({
                   <Redo2 className="w-4 h-4" /> Redo
                 </button>
               </div>
-            </div>
+            )}
           </div>
         </div>
+      </div>
       </div>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">

--- a/src/hooks/useGameState.test.ts
+++ b/src/hooks/useGameState.test.ts
@@ -104,6 +104,15 @@ describe('useGameState initialization', () => {
   });
 });
 
+describe('showUndoRedo setting', () => {
+  it('toggles visibility flag', () => {
+    const { result } = renderHook(() => useGameState());
+    expect(result.current.gameState.showUndoRedo).toBe(true);
+    result.current.setShowUndoRedo(false);
+    expect(result.current.gameState.showUndoRedo).toBe(false);
+  });
+});
+
 describe('useGameState player management', () => {
   it('removes player and adjusts team totals', () => {
     const { result } = renderHook(() => useGameState());

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -83,6 +83,7 @@ const initialState: GameState = {
   },
   gamePreset: GAME_PRESETS[3], // Default to Futsal Regular
   matchPhase: 'regular',
+  showUndoRedo: true,
 };
 
 const STORAGE_KEY = 'gameState';
@@ -128,6 +129,8 @@ export const useGameState = () => {
               ...initialState.gamePreset,
               ...parsed.gamePreset,
             },
+            showUndoRedo:
+              parsed.showUndoRedo ?? initialState.showUndoRedo,
           } as GameState;
         } catch {
           // ignore malformed stored state
@@ -183,6 +186,10 @@ export const useGameState = () => {
       tournamentLogo: logo,
     }));
   }, [setGameState]);
+
+  const setShowUndoRedo = useCallback((value: boolean) => {
+    _setGameState(prev => ({ ...prev, showUndoRedo: value }));
+  }, []);
 
   const updateTeamStats = useCallback((team: 'home' | 'away', stat: keyof Team['stats'], value: number) => {
     setGameState(prev => {
@@ -818,6 +825,7 @@ export const useGameState = () => {
     addPlayer,
     removePlayer,
     updatePlayerStats,
+    setShowUndoRedo,
     switchBallPossession,
     updateTime,
     toggleTimer,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,4 +58,5 @@ export interface GameState {
   };
   gamePreset: GamePreset;
   matchPhase: 'regular' | 'extra-time' | 'penalties';
+  showUndoRedo: boolean;
 }


### PR DESCRIPTION
## Summary
- add `showUndoRedo` flag to game state with persistence helpers
- provide settings toggle to control undo/redo button visibility
- render undo/redo controls only when enabled

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx vitest run` *(fails: 403 Forbidden fetching vitest)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893a8222ad0832da328526880e3638d