### PR TITLE
Add match summary view and navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,8 +9,15 @@ import { PossessionTracker } from './components/PossessionTracker';
 import { ControlPanelButton } from './components/ControlPanelButton';
 import { ThemeToggle } from './components/ThemeToggle';
 import { RemoteControl } from './components/RemoteControl';
+import { MatchSummary } from './components/MatchSummary';
 
-type ViewMode = 'scoreboard' | 'dashboard' | 'overlay' | 'stats' | 'possession';
+type ViewMode =
+  | 'scoreboard'
+  | 'dashboard'
+  | 'overlay'
+  | 'stats'
+  | 'possession'
+  | 'summary';
 
 function App() {
   const [route, setRoute] = useState(
@@ -70,6 +77,12 @@ function App() {
             gameState={gameState.gameState}
             switchBallPossession={gameState.switchBallPossession}
           />
+          {/* Floating control button */}
+          <ControlPanelButton onClick={() => setViewMode('dashboard')} />
+        </div>
+      ) : viewMode === 'summary' ? (
+        <div className="relative">
+          <MatchSummary gameState={gameState.gameState} />
           {/* Floating control button */}
           <ControlPanelButton onClick={() => setViewMode('dashboard')} />
         </div>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -15,6 +15,7 @@ import {
   Timer,
   Undo2,
   Redo2,
+  FileText,
 } from 'lucide-react';
 
 interface DashboardProps {
@@ -31,7 +32,9 @@ interface DashboardProps {
   redo: () => void;
   addPlayer: (team: 'home' | 'away', name: string) => void;
   removePlayer: (team: 'home' | 'away', playerId: string) => void;
-  onViewChange: (view: 'scoreboard' | 'dashboard' | 'overlay' | 'stats' | 'possession') => void;
+  onViewChange: (
+    view: 'scoreboard' | 'dashboard' | 'overlay' | 'stats' | 'possession' | 'summary'
+  ) => void;
 }
 
 export const Dashboard: React.FC<DashboardProps> = ({
@@ -195,6 +198,13 @@ export const Dashboard: React.FC<DashboardProps> = ({
           <div className="flex justify-between items-center py-4">
             <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Futsal Scoreboard Control</h1>
             <div className="flex gap-3">
+              <button
+                onClick={() => onViewChange('summary')}
+                className="inline-flex items-center gap-2 px-4 py-2 bg-teal-600 text-white rounded-lg hover:bg-teal-700 transition-colors"
+              >
+                <FileText className="w-4 h-4" />
+                Match Summary
+              </button>
               <button
                 onClick={() => onViewChange('scoreboard')}
                 className="inline-flex items-center gap-2 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors"

--- a/src/components/MatchSummary.tsx
+++ b/src/components/MatchSummary.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { GameState } from '../types';
+
+interface MatchSummaryProps {
+  gameState: GameState;
+}
+
+export const MatchSummary: React.FC<MatchSummaryProps> = ({ gameState }) => {
+  const { homeTeam, awayTeam, gamePreset } = gameState;
+
+  return (
+    <div className="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100 flex items-center justify-center p-4">
+      <div className="w-full max-w-xl bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6 space-y-6">
+        <div className="text-center">
+          <h2 className="text-2xl font-bold mb-4">Match Summary</h2>
+          <div className="flex items-center justify-center gap-6 mb-4">
+            <div className="flex items-center gap-2">
+              <div className="w-12 h-12 rounded-full overflow-hidden bg-gray-100 dark:bg-gray-700 flex items-center justify-center">
+                {homeTeam.logo ? (
+                  <img src={homeTeam.logo} alt="Home" className="w-full h-full object-cover" />
+                ) : (
+                  <span className="text-lg font-bold text-gray-500 dark:text-gray-400">
+                    {homeTeam.name.charAt(0)}
+                  </span>
+                )}
+              </div>
+              <span className="font-semibold">{homeTeam.name}</span>
+            </div>
+            <span className="text-gray-500 dark:text-gray-400 font-medium">vs</span>
+            <div className="flex items-center gap-2">
+              <span className="font-semibold">{awayTeam.name}</span>
+              <div className="w-12 h-12 rounded-full overflow-hidden bg-gray-100 dark:bg-gray-700 flex items-center justify-center">
+                {awayTeam.logo ? (
+                  <img src={awayTeam.logo} alt="Away" className="w-full h-full object-cover" />
+                ) : (
+                  <span className="text-lg font-bold text-gray-500 dark:text-gray-400">
+                    {awayTeam.name.charAt(0)}
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+          <p className="text-sm text-gray-600 dark:text-gray-400">{gamePreset.name}</p>
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex justify-between">
+            <span>Game Type</span>
+            <span className="font-medium capitalize">{gamePreset.type}</span>
+          </div>
+          <div className="flex justify-between">
+            <span>Format</span>
+            <span className="font-medium capitalize">{gamePreset.format}</span>
+          </div>
+          <div className="flex justify-between">
+            <span>Half Duration</span>
+            <span className="font-medium">{gamePreset.halfDuration} minutes</span>
+          </div>
+          <div className="flex justify-between">
+            <span>Total Halves</span>
+            <span className="font-medium">{gamePreset.totalHalves}</span>
+          </div>
+          <div className="flex justify-between">
+            <span>Extra Time</span>
+            <span className="font-medium">
+              {gamePreset.hasExtraTime
+                ? `${gamePreset.extraTimeDuration} minutes per half`
+                : 'No'}
+            </span>
+          </div>
+          <div className="flex justify-between">
+            <span>Penalties</span>
+            <span className="font-medium">{gamePreset.hasPenalties ? 'Yes' : 'No'}</span>
+          </div>
+          <div className="flex justify-between">
+            <span>Allows Draws</span>
+            <span className="font-medium">{gamePreset.allowsDraws ? 'Yes' : 'No'}</span>
+          </div>
+        </div>
+
+        {gamePreset.description && (
+          <p className="text-sm text-gray-600 dark:text-gray-400 text-center">
+            {gamePreset.description}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MatchSummary;


### PR DESCRIPTION
## Summary
- add MatchSummary component to present game preset and team details
- wire new summary view into App and dashboard navigation

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893a82552e8832d81fa0891f66746a4