### PR TITLE
feat: add match summary component

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -4,6 +4,7 @@ import { ExternalControlInfo } from './ExternalControlInfo';
 import { GamePresetSelector } from './GamePresetSelector';
 import { getHalfName } from '../utils/gamePresets';
 import { ConfirmModal } from './ConfirmModal';
+import { MatchSummary } from './MatchSummary';
 import {
   Play,
   Pause,
@@ -257,6 +258,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
       </div>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <MatchSummary gameState={gameState} />
         {/* Navigation Tabs */}
         <div className="mb-8">
           <div className="border-b border-gray-200">

--- a/src/components/MatchSummary.tsx
+++ b/src/components/MatchSummary.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { GameState } from '../types';
+import { Info } from 'lucide-react';
+
+interface MatchSummaryProps {
+  gameState: GameState;
+}
+
+export const MatchSummary: React.FC<MatchSummaryProps> = ({ gameState }) => {
+  const { homeTeam, awayTeam, gamePreset, half, matchPhase } = gameState;
+
+  return (
+    <div className="bg-blue-50 dark:bg-blue-900 rounded-xl border border-blue-200 dark:border-blue-700 p-4 mb-8">
+      <h3 className="text-lg font-semibold text-blue-900 dark:text-blue-100 mb-4 flex items-center gap-2">
+        <Info className="w-5 h-5" />
+        Match Summary
+      </h3>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-blue-900 dark:text-blue-100">
+        <div>
+          <span className="font-medium">Home Team:</span> {homeTeam.name}
+        </div>
+        <div>
+          <span className="font-medium">Away Team:</span> {awayTeam.name}
+        </div>
+        <div>
+          <span className="font-medium">Format:</span> {gamePreset.name}
+        </div>
+        <div>
+          <span className="font-medium">Half Duration:</span> {gamePreset.halfDuration} min
+        </div>
+        <div>
+          <span className="font-medium">Total Halves:</span> {gamePreset.totalHalves}
+        </div>
+        {gamePreset.hasExtraTime && (
+          <div>
+            <span className="font-medium">Extra Time:</span> {gamePreset.extraTimeDuration} min halves
+          </div>
+        )}
+        {gamePreset.hasPenalties && (
+          <div>
+            <span className="font-medium">Penalties:</span> Yes
+          </div>
+        )}
+        <div>
+          <span className="font-medium">Current Period:</span> {half}
+        </div>
+        <div>
+          <span className="font-medium">Phase:</span> {matchPhase}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MatchSummary;


### PR DESCRIPTION
## Summary
- add `MatchSummary` component to display configured teams and match preset details
- show summary in dashboard landing view for quick confirmation of match settings

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893aed8d434832dbfe82d1a6cd67696