### PR TITLE
feat: add settings page route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { PossessionTracker } from './components/PossessionTracker';
 import { ControlPanelButton } from './components/ControlPanelButton';
 import { ThemeToggle } from './components/ThemeToggle';
 import { RemoteControl } from './components/RemoteControl';
+import { SettingsPage } from './components/SettingsPage';
 
 type ViewMode = 'scoreboard' | 'dashboard' | 'overlay' | 'stats' | 'possession';
 
@@ -90,7 +91,6 @@ function App() {
                 resetTimer={gameState.resetTimer}
                 updatePeriod={gameState.updatePeriod}
                 changeGamePreset={gameState.changeGamePreset}
-                resetGame={gameState.resetGame}
                 undo={gameState.undo}
                 redo={gameState.redo}
                 addPlayer={gameState.addPlayer}
@@ -103,6 +103,16 @@ function App() {
           <Route path="/overlay" element={<OverlayView />} />
           <Route path="/stats" element={<StatsView />} />
           <Route path="/possession" element={<PossessionView />} />
+          <Route
+            path="/settings"
+            element={
+              <SettingsPage
+                gameState={gameState.gameState}
+                updateTeam={gameState.updateTeam}
+                resetGame={gameState.resetGame}
+              />
+            }
+          />
           <Route path="/" element={<Navigate to="/dashboard" replace />} />
           <Route path="*" element={<Navigate to="/dashboard" replace />} />
         </Routes>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,13 +1,11 @@
 import React, { useState, useRef, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { GameState } from '../types';
-import { ExternalControlInfo } from './ExternalControlInfo';
 import { GamePresetSelector } from './GamePresetSelector';
 import { getHalfName } from '../utils/gamePresets';
-import { ConfirmModal } from './ConfirmModal';
 import {
   Play,
   Pause,
-  RotateCcw,
   Plus,
   Minus,
   Upload,
@@ -16,6 +14,7 @@ import {
   Timer,
   Undo2,
   Redo2,
+  Settings,
 } from 'lucide-react';
 
 interface DashboardProps {
@@ -27,7 +26,6 @@ interface DashboardProps {
   resetTimer: () => void;
   updatePeriod: (period: number) => void;
   changeGamePreset: (presetIndex: number) => void;
-  resetGame: (options?: { force?: boolean }) => void;
   undo: () => void;
   redo: () => void;
   addPlayer: (team: 'home' | 'away', name: string) => void;
@@ -44,23 +42,20 @@ export const Dashboard: React.FC<DashboardProps> = ({
   resetTimer,
   updatePeriod,
   changeGamePreset,
-  resetGame,
   undo,
   redo,
   addPlayer,
   removePlayer,
   onViewChange,
 }) => {
-  const [activeTab, setActiveTab] = useState<'teams' | 'timer' | 'format' | 'settings'>('teams');
-  const tabs = ['teams', 'timer', 'format', 'settings'] as const;
+  const [activeTab, setActiveTab] = useState<'teams' | 'timer' | 'format'>('teams');
+  const tabs = ['teams', 'timer', 'format'] as const;
 
   const [homeLogoError, setHomeLogoError] = useState('');
   const [awayLogoError, setAwayLogoError] = useState('');
   const [tournamentLogoError, setTournamentLogoError] = useState('');
   const [homePlayerName, setHomePlayerName] = useState('');
   const [awayPlayerName, setAwayPlayerName] = useState('');
-
-  const [showResetConfirm, setShowResetConfirm] = useState(false);
 
   const homeLogoUrlRef = useRef<string | null>(null);
   const awayLogoUrlRef = useRef<string | null>(null);
@@ -173,34 +168,6 @@ export const Dashboard: React.FC<DashboardProps> = ({
     }
   };
 
-  const handleResetGame = () => {
-    const hasStarted =
-      gameState.isRunning ||
-      gameState.time.minutes !== gameState.gamePreset.halfDuration ||
-      gameState.time.seconds !== 0 ||
-      gameState.homeTeam.score !== 0 ||
-      gameState.awayTeam.score !== 0 ||
-      gameState.homeTeam.fouls !== 0 ||
-      gameState.awayTeam.fouls !== 0 ||
-      Object.values(gameState.homeTeam.stats).some(v => v !== 0) ||
-      Object.values(gameState.awayTeam.stats).some(v => v !== 0);
-
-    if (!hasStarted) {
-      resetGame({ force: true });
-    } else {
-      setShowResetConfirm(true);
-    }
-  };
-
-  const confirmResetGame = () => {
-    resetGame({ force: true });
-    setShowResetConfirm(false);
-  };
-
-  const cancelResetGame = () => {
-    setShowResetConfirm(false);
-  };
-
   return (
     <div className="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
       {/* Header */}
@@ -237,6 +204,13 @@ export const Dashboard: React.FC<DashboardProps> = ({
                 <Timer className="w-4 h-4" />
                 Possession Control
               </button>
+              <Link
+                to="/settings"
+                className="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 transition-colors"
+              >
+                <Settings className="w-4 h-4" />
+                Settings
+              </Link>
               <button
                 onClick={undo}
                 className="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 transition-colors"
@@ -701,64 +675,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
           />
         )}
 
-        {/* Settings Tab */}
-        {activeTab === 'settings' && (
-          <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-8 max-w-2xl mx-auto">
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-8 text-center">Game Settings</h3>
-            
-            <div className="space-y-8">
-              {/* External Control Info */}
-              <ExternalControlInfo />
-
-              <div className="text-center">
-                <button
-                  onClick={handleResetGame}
-                  className="inline-flex items-center gap-2 px-6 py-3 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors font-semibold"
-                >
-                  <RotateCcw className="w-5 h-5" />
-                  Reset Entire Game
-                </button>
-                <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
-                  This will reset scores, fouls, timer, and all settings to default values.
-                </p>
-              </div>
-
-              <div className="border-t pt-6">
-                <h4 className="font-semibold text-gray-900 dark:text-gray-100 mb-4">Quick Actions</h4>
-                <div className="grid grid-cols-2 gap-4">
-                  <button
-                    onClick={() => {
-                      updateTeam('home', 'score', 0);
-                      updateTeam('away', 'score', 0);
-                    }}
-                    className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
-                  >
-                    Reset Scores
-                  </button>
-                  <button
-                    onClick={() => {
-                      updateTeam('home', 'fouls', 0);
-                      updateTeam('away', 'fouls', 0);
-                    }}
-                    className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
-                  >
-                    Reset Fouls
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
       </div>
-      <ConfirmModal
-        isOpen={showResetConfirm}
-        title="Reset Game"
-        message="Are you sure you want to reset the entire game?"
-        confirmText="Reset"
-        cancelText="Cancel"
-        onConfirm={confirmResetGame}
-        onCancel={cancelResetGame}
-      />
     </div>
   );
 };

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,0 +1,110 @@
+import React, { useState } from 'react';
+import { RotateCcw } from 'lucide-react';
+import { GameState } from '../types';
+import { ExternalControlInfo } from './ExternalControlInfo';
+import { ConfirmModal } from './ConfirmModal';
+
+interface SettingsPageProps {
+  gameState: GameState;
+  updateTeam: (team: 'home' | 'away', field: 'score' | 'fouls', value: number) => void;
+  resetGame: (options?: { force?: boolean }) => void;
+}
+
+export const SettingsPage: React.FC<SettingsPageProps> = ({
+  gameState,
+  updateTeam,
+  resetGame,
+}) => {
+  const [showResetConfirm, setShowResetConfirm] = useState(false);
+
+  const handleResetGame = () => {
+    const hasStarted =
+      gameState.isRunning ||
+      gameState.time.minutes !== gameState.gamePreset.halfDuration ||
+      gameState.time.seconds !== 0 ||
+      gameState.homeTeam.score !== 0 ||
+      gameState.awayTeam.score !== 0 ||
+      gameState.homeTeam.fouls !== 0 ||
+      gameState.awayTeam.fouls !== 0 ||
+      Object.values(gameState.homeTeam.stats).some(v => v !== 0) ||
+      Object.values(gameState.awayTeam.stats).some(v => v !== 0);
+
+    if (!hasStarted) {
+      resetGame({ force: true });
+    } else {
+      setShowResetConfirm(true);
+    }
+  };
+
+  const confirmResetGame = () => {
+    resetGame({ force: true });
+    setShowResetConfirm(false);
+  };
+
+  const cancelResetGame = () => {
+    setShowResetConfirm(false);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-8 max-w-2xl mx-auto">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-8 text-center">Game Settings</h3>
+
+          <div className="space-y-8">
+            <ExternalControlInfo />
+
+            <div className="text-center">
+              <button
+                onClick={handleResetGame}
+                className="inline-flex items-center gap-2 px-6 py-3 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors font-semibold"
+              >
+                <RotateCcw className="w-5 h-5" />
+                Reset Entire Game
+              </button>
+              <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
+                This will reset scores, fouls, timer, and all settings to default values.
+              </p>
+            </div>
+
+            <div className="border-t pt-6">
+              <h4 className="font-semibold text-gray-900 dark:text-gray-100 mb-4">Quick Actions</h4>
+              <div className="grid grid-cols-2 gap-4">
+                <button
+                  onClick={() => {
+                    updateTeam('home', 'score', 0);
+                    updateTeam('away', 'score', 0);
+                  }}
+                  className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+                >
+                  Reset Scores
+                </button>
+                <button
+                  onClick={() => {
+                    updateTeam('home', 'fouls', 0);
+                    updateTeam('away', 'fouls', 0);
+                  }}
+                  className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+                >
+                  Reset Fouls
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <ConfirmModal
+        isOpen={showResetConfirm}
+        title="Reset Game"
+        message="Are you sure you want to reset the entire game?"
+        confirmText="Reset"
+        cancelText="Cancel"
+        onConfirm={confirmResetGame}
+        onCancel={cancelResetGame}
+      />
+    </div>
+  );
+};
+
+export default SettingsPage;


### PR DESCRIPTION
## Summary
- add dedicated `SettingsPage` component with reset controls and quick actions
- expose `/settings` route to render the settings page
- link to the settings page from the dashboard header

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893aed52a78832d903aa3b4c5be9306