### PR TITLE
Add tournament name and logo settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -85,6 +85,7 @@ function App() {
                 gameState={gameState.gameState}
                 updateTeam={gameState.updateTeam}
                 updateTournamentLogo={gameState.updateTournamentLogo}
+                updateTournamentName={gameState.updateTournamentName}
                 updateTime={gameState.updateTime}
                 toggleTimer={gameState.toggleTimer}
                 resetTimer={gameState.resetTimer}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -22,6 +22,7 @@ interface DashboardProps {
   gameState: GameState;
   updateTeam: (team: 'home' | 'away', field: 'name' | 'score' | 'fouls' | 'logo', value: string | number) => void;
   updateTournamentLogo: (logo: string) => void;
+  updateTournamentName: (name: string) => void;
   updateTime: (minutes: number, seconds: number) => void;
   toggleTimer: () => void;
   resetTimer: () => void;
@@ -39,6 +40,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
   gameState,
   updateTeam,
   updateTournamentLogo,
+  updateTournamentName,
   updateTime,
   toggleTimer,
   resetTimer,
@@ -281,47 +283,6 @@ export const Dashboard: React.FC<DashboardProps> = ({
         {/* Teams Tab */}
         {activeTab === 'teams' && (
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-            {/* Tournament Logo Section */}
-            <div className="lg:col-span-2 bg-purple-50 dark:bg-purple-900 rounded-xl border border-purple-200 dark:border-purple-700 p-6 mb-6">
-              <h3 className="text-lg font-semibold text-purple-900 dark:text-purple-100 mb-4">Tournament Logo</h3>
-              <div className="flex items-center gap-6">
-                <div className="w-20 h-20 bg-gray-100 dark:bg-gray-700 rounded-lg overflow-hidden flex items-center justify-center border-2 border-gray-300 dark:border-gray-600">
-                  {gameState.tournamentLogo ? (
-                    <img src={gameState.tournamentLogo} alt="Tournament" className="w-full h-full object-contain" />
-                  ) : (
-                    <span className="text-gray-400 text-xs text-center">No Logo</span>
-                  )}
-                </div>
-                <div className="flex gap-3">
-                  <label className="cursor-pointer inline-flex items-center gap-2 px-4 py-2 bg-purple-100 text-purple-700 rounded-lg hover:bg-purple-200 transition-colors dark:bg-purple-900 dark:text-purple-200 dark:hover:bg-purple-800">
-                    <Upload className="w-4 h-4" />
-                    Upload Tournament Logo
-                    <input
-                      type="file"
-                      accept="image/*"
-                      onChange={handleTournamentLogoUpload}
-                      className="hidden"
-                    />
-                  </label>
-                  {gameState.tournamentLogo && (
-                    <button
-                      onClick={() => updateTournamentLogo('')}
-                      className="px-4 py-2 bg-red-100 text-red-700 rounded-lg hover:bg-red-200 transition-colors dark:bg-red-900 dark:text-red-200 dark:hover:bg-red-800"
-                    >
-                      Remove Logo
-                    </button>
-                  )}
-                </div>
-                <div className="text-sm text-gray-600 dark:text-gray-300">
-                  <p>Upload a tournament logo to display at the top of the scoreboard.</p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">Leave blank to show no header logo.</p>
-                </div>
-              </div>
-              {tournamentLogoError && (
-                <p className="text-sm text-red-600 dark:text-red-400 mt-2">{tournamentLogoError}</p>
-              )}
-            </div>
-
             {/* Timer Controls - Quick Access */}
             <div className="lg:col-span-2 bg-green-50 dark:bg-green-900 rounded-xl border border-green-200 dark:border-green-700 p-4 mb-4">
               <div className="flex items-center justify-between">
@@ -707,6 +668,49 @@ export const Dashboard: React.FC<DashboardProps> = ({
             <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-8 text-center">Game Settings</h3>
             
             <div className="space-y-8">
+              {/* Tournament Settings */}
+              <div className="space-y-6">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Tournament Name</label>
+                  <input
+                    type="text"
+                    value={gameState.tournamentName}
+                    onChange={e => updateTournamentName(e.target.value)}
+                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500 dark:bg-gray-700 dark:text-gray-100"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Tournament Logo</label>
+                  <div className="flex items-center gap-6">
+                    <div className="w-20 h-20 bg-gray-100 dark:bg-gray-700 rounded-lg overflow-hidden flex items-center justify-center border-2 border-gray-300 dark:border-gray-600">
+                      {gameState.tournamentLogo ? (
+                        <img src={gameState.tournamentLogo} alt="Tournament" className="w-full h-full object-contain" />
+                      ) : (
+                        <span className="text-gray-400 text-xs text-center">No Logo</span>
+                      )}
+                    </div>
+                    <div className="flex gap-3">
+                      <label className="cursor-pointer inline-flex items-center gap-2 px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600">
+                        <Upload className="w-4 h-4" />
+                        Upload Logo
+                        <input type="file" accept="image/*" onChange={handleTournamentLogoUpload} className="hidden" />
+                      </label>
+                      {gameState.tournamentLogo && (
+                        <button
+                          onClick={() => updateTournamentLogo('')}
+                          className="px-4 py-2 bg-red-100 text-red-700 rounded-lg hover:bg-red-200 transition-colors dark:bg-red-900 dark:text-red-200 dark:hover:bg-red-800"
+                        >
+                          Remove Logo
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                  {tournamentLogoError && (
+                    <p className="text-sm text-red-600 dark:text-red-400 mt-2">{tournamentLogoError}</p>
+                  )}
+                </div>
+              </div>
+
               {/* External Control Info */}
               <ExternalControlInfo />
 

--- a/src/components/Scoreboard.tsx
+++ b/src/components/Scoreboard.tsx
@@ -23,21 +23,26 @@ export const Scoreboard: React.FC<ScoreboardProps> = ({ gameState }) => {
       <div className="w-full h-full flex items-center justify-center px-8 py-6">
         {/* Main Scoreboard */}
         <div className="bg-white/60 dark:bg-black/40 backdrop-blur-lg rounded-3xl border border-gray-200 dark:border-gray-700/50 shadow-2xl w-full max-w-7xl h-full max-h-[900px] flex flex-col justify-center p-12">
-          {/* Header */}
-          {gameState.tournamentLogo && (
-            <div className="text-center mb-12">
-              <div className="inline-flex items-center justify-center bg-white/10 backdrop-blur-sm px-8 py-6 rounded-2xl border border-white/20">
-                <img 
-                  src={gameState.tournamentLogo} 
-                  alt="Tournament Logo"
-                  className="max-h-16 max-w-64 object-contain"
-                />
+            {/* Header */}
+            {(gameState.tournamentLogo || gameState.tournamentName) && (
+              <div className="text-center mb-12">
+                <div className="inline-flex items-center justify-center gap-4 bg-white/10 backdrop-blur-sm px-8 py-6 rounded-2xl border border-white/20">
+                  {gameState.tournamentLogo && (
+                    <img
+                      src={gameState.tournamentLogo}
+                      alt="Tournament Logo"
+                      className="max-h-16 max-w-64 object-contain"
+                    />
+                  )}
+                  {gameState.tournamentName && (
+                    <span className="text-3xl font-bold">{gameState.tournamentName}</span>
+                  )}
+                </div>
               </div>
-            </div>
-          )}
+            )}
 
           {/* Teams and Score */}
-          <div className={`grid grid-cols-3 gap-16 items-center flex-1 ${!gameState.tournamentLogo ? 'justify-center' : ''}`}>
+          <div className={`grid grid-cols-3 gap-16 items-center flex-1 ${!gameState.tournamentLogo && !gameState.tournamentName ? 'justify-center' : ''}`}>
             {/* Home Team */}
             <div className="text-center space-y-6">
               <div className="relative">

--- a/src/hooks/useGameState.test.ts
+++ b/src/hooks/useGameState.test.ts
@@ -104,6 +104,18 @@ describe('useGameState initialization', () => {
   });
 });
 
+describe('tournament settings', () => {
+  it('updates tournament name and logo', () => {
+    const { result } = renderHook(() => useGameState());
+
+    result.current.updateTournamentName('Championship');
+    result.current.updateTournamentLogo('logo-url');
+
+    expect(result.current.gameState.tournamentName).toBe('Championship');
+    expect(result.current.gameState.tournamentLogo).toBe('logo-url');
+  });
+});
+
 describe('useGameState player management', () => {
   it('removes player and adjusts team totals', () => {
     const { result } = renderHook(() => useGameState());

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -69,6 +69,7 @@ const initialState: GameState = {
     },
     players: [],
   },
+  tournamentName: '',
   time: {
     minutes: 20, // Will be set by preset
     seconds: 0,
@@ -181,6 +182,13 @@ export const useGameState = () => {
     setGameState(prev => ({
       ...prev,
       tournamentLogo: logo,
+    }));
+  }, [setGameState]);
+
+  const updateTournamentName = useCallback((name: string) => {
+    setGameState(prev => ({
+      ...prev,
+      tournamentName: name,
     }));
   }, [setGameState]);
 
@@ -814,6 +822,7 @@ export const useGameState = () => {
     gameState,
     updateTeam,
     updateTournamentLogo,
+    updateTournamentName,
     updateTeamStats,
     addPlayer,
     removePlayer,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -44,6 +44,7 @@ export interface GameState {
   homeTeam: Team;
   awayTeam: Team;
   tournamentLogo?: string;
+  tournamentName?: string;
   time: {
     minutes: number;
     seconds: number;


### PR DESCRIPTION
## Summary
- allow storing a tournament name in game state alongside the tournament logo
- move tournament logo controls to Settings tab and add tournament name input
- show tournament name on the scoreboard header

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893aed1cf5c832d8d86c97efb0b8f5f