### PR TITLE
feat: add undo/redo visibility setting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -96,6 +96,7 @@ function App() {
                 addPlayer={gameState.addPlayer}
                 removePlayer={gameState.removePlayer}
                 onViewChange={handleViewChange}
+                setShowUndoRedo={gameState.setShowUndoRedo}
               />
             }
           />

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -33,6 +33,7 @@ interface DashboardProps {
   addPlayer: (team: 'home' | 'away', name: string) => void;
   removePlayer: (team: 'home' | 'away', playerId: string) => void;
   onViewChange: (view: 'scoreboard' | 'dashboard' | 'overlay' | 'stats' | 'possession') => void;
+  setShowUndoRedo: (show: boolean) => void;
 }
 
 export const Dashboard: React.FC<DashboardProps> = ({
@@ -50,6 +51,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
   addPlayer,
   removePlayer,
   onViewChange,
+  setShowUndoRedo,
 }) => {
   const [activeTab, setActiveTab] = useState<'teams' | 'timer' | 'format' | 'settings'>('teams');
   const tabs = ['teams', 'timer', 'format', 'settings'] as const;
@@ -237,20 +239,24 @@ export const Dashboard: React.FC<DashboardProps> = ({
                 <Timer className="w-4 h-4" />
                 Possession Control
               </button>
-              <button
-                onClick={undo}
-                className="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 transition-colors"
-              >
-                <Undo2 className="w-4 h-4" />
-                Undo
-              </button>
-              <button
-                onClick={redo}
-                className="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 transition-colors"
-              >
-                <Redo2 className="w-4 h-4" />
-                Redo
-              </button>
+              {gameState.showUndoRedo && (
+                <>
+                  <button
+                    onClick={undo}
+                    className="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 transition-colors"
+                  >
+                    <Undo2 className="w-4 h-4" />
+                    Undo
+                  </button>
+                  <button
+                    onClick={redo}
+                    className="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 transition-colors"
+                  >
+                    <Redo2 className="w-4 h-4" />
+                    Redo
+                  </button>
+                </>
+              )}
             </div>
           </div>
         </div>
@@ -706,13 +712,26 @@ export const Dashboard: React.FC<DashboardProps> = ({
           <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-8 max-w-2xl mx-auto">
             <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-8 text-center">Game Settings</h3>
             
-            <div className="space-y-8">
-              {/* External Control Info */}
-              <ExternalControlInfo />
+              <div className="space-y-8">
+                {/* External Control Info */}
+                <ExternalControlInfo />
 
-              <div className="text-center">
-                <button
-                  onClick={handleResetGame}
+                <div className="border-t pt-6">
+                  <h4 className="font-semibold text-gray-900 dark:text-gray-100 mb-4">Display Options</h4>
+                  <label className="flex items-center justify-between">
+                    <span className="text-gray-700 dark:text-gray-300">Show Undo/Redo Buttons</span>
+                    <input
+                      type="checkbox"
+                      checked={gameState.showUndoRedo}
+                      onChange={e => setShowUndoRedo(e.target.checked)}
+                      className="w-4 h-4"
+                    />
+                  </label>
+                </div>
+
+                <div className="text-center">
+                  <button
+                    onClick={handleResetGame}
                   className="inline-flex items-center gap-2 px-6 py-3 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors font-semibold"
                 >
                   <RotateCcw className="w-5 h-5" />

--- a/src/hooks/useGameState.test.ts
+++ b/src/hooks/useGameState.test.ts
@@ -104,6 +104,17 @@ describe('useGameState initialization', () => {
   });
 });
 
+describe('useGameState settings', () => {
+  it('toggles showUndoRedo setting', () => {
+    const { result } = renderHook(() => useGameState());
+
+    expect(result.current.gameState.showUndoRedo).toBe(true);
+
+    result.current.setShowUndoRedo(false);
+    expect(result.current.gameState.showUndoRedo).toBe(false);
+  });
+});
+
 describe('useGameState player management', () => {
   it('removes player and adjusts team totals', () => {
     const { result } = renderHook(() => useGameState());

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -83,6 +83,7 @@ const initialState: GameState = {
   },
   gamePreset: GAME_PRESETS[3], // Default to Futsal Regular
   matchPhase: 'regular',
+  showUndoRedo: true,
 };
 
 const STORAGE_KEY = 'gameState';
@@ -283,6 +284,10 @@ export const useGameState = () => {
     },
     [setGameState],
   );
+
+  const setShowUndoRedo = useCallback((show: boolean) => {
+    _setGameState(prev => ({ ...prev, showUndoRedo: show }));
+  }, []);
 
   const switchBallPossession = useCallback((newTeam: 'home' | 'away') => {
     setGameState(prev => {
@@ -827,5 +832,6 @@ export const useGameState = () => {
     resetGame,
     undo,
     redo,
+    setShowUndoRedo,
   };
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,4 +58,5 @@ export interface GameState {
   };
   gamePreset: GamePreset;
   matchPhase: 'regular' | 'extra-time' | 'penalties';
+  showUndoRedo: boolean;
 }


### PR DESCRIPTION
## Summary
- add `showUndoRedo` preference to game state
- allow toggling undo/redo buttons in dashboard settings
- hide undo/redo controls when disabled

## Testing
- `npm run lint`
- `npx vitest run` *(fails: 403 Forbidden fetching vitest)*

------
https://chatgpt.com/codex/tasks/task_e_6893aed726d0832d803a6f6b73e84d89