### PR TITLE
feat: add settings page with undo redo toggles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,8 +16,16 @@ import { PossessionTracker } from './components/PossessionTracker';
 import { ControlPanelButton } from './components/ControlPanelButton';
 import { ThemeToggle } from './components/ThemeToggle';
 import { RemoteControl } from './components/RemoteControl';
+import { SettingsProvider } from './hooks/useSettings';
+import { SettingsPage } from './components/SettingsPage';
 
-type ViewMode = 'scoreboard' | 'dashboard' | 'overlay' | 'stats' | 'possession';
+type ViewMode =
+  | 'scoreboard'
+  | 'dashboard'
+  | 'overlay'
+  | 'stats'
+  | 'possession'
+  | 'settings';
 
 function App() {
   const gameState = useGameState();
@@ -74,6 +82,13 @@ function App() {
       </div>
     );
 
+    const SettingsView: React.FC = () => (
+      <div className="relative">
+        <SettingsPage />
+        <ControlPanelButton onClick={() => navigate('/dashboard')} />
+      </div>
+    );
+
     return (
       <div className="App">
         <ThemeToggle theme={theme} onToggle={toggleTheme} />
@@ -104,6 +119,7 @@ function App() {
           <Route path="/overlay" element={<OverlayView />} />
           <Route path="/stats" element={<StatsView />} />
           <Route path="/possession" element={<PossessionView />} />
+          <Route path="/settings" element={<SettingsView />} />
           <Route path="/" element={<Navigate to="/dashboard" replace />} />
           <Route path="*" element={<Navigate to="/dashboard" replace />} />
         </Routes>
@@ -112,12 +128,14 @@ function App() {
   };
 
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/remote" element={<RemoteControl />} />
-        <Route path="/*" element={<MainLayout />} />
-      </Routes>
-    </BrowserRouter>
+    <SettingsProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/remote" element={<RemoteControl />} />
+          <Route path="/*" element={<MainLayout />} />
+        </Routes>
+      </BrowserRouter>
+    </SettingsProvider>
   );
 }
 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -17,7 +17,9 @@ import {
   Timer,
   Undo2,
   Redo2,
+  Settings,
 } from 'lucide-react';
+import { useSettings } from '../hooks/useSettings';
 
 interface DashboardProps {
   gameState: GameState;
@@ -34,7 +36,9 @@ interface DashboardProps {
   redo: () => void;
   addPlayer: (team: 'home' | 'away', name: string) => void;
   removePlayer: (team: 'home' | 'away', playerId: string) => void;
-  onViewChange: (view: 'scoreboard' | 'dashboard' | 'overlay' | 'stats' | 'possession') => void;
+  onViewChange: (
+    view: 'scoreboard' | 'dashboard' | 'overlay' | 'stats' | 'possession' | 'settings'
+  ) => void;
 }
 
 export const Dashboard: React.FC<DashboardProps> = ({
@@ -56,6 +60,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
 }) => {
   const [activeTab, setActiveTab] = useState<'teams' | 'timer' | 'format' | 'settings'>('teams');
   const tabs = ['teams', 'timer', 'format', 'settings'] as const;
+  const { settings } = useSettings();
 
   const [homeLogoError, setHomeLogoError] = useState('');
   const [awayLogoError, setAwayLogoError] = useState('');
@@ -241,19 +246,30 @@ export const Dashboard: React.FC<DashboardProps> = ({
                 Possession Control
               </button>
               <button
-                onClick={undo}
+                onClick={() => onViewChange('settings')}
                 className="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 transition-colors"
               >
-                <Undo2 className="w-4 h-4" />
-                Undo
+                <Settings className="w-4 h-4" />
+                Settings
               </button>
-              <button
-                onClick={redo}
-                className="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 transition-colors"
-              >
-                <Redo2 className="w-4 h-4" />
-                Redo
-              </button>
+              {settings.showUndo && (
+                <button
+                  onClick={undo}
+                  className="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 transition-colors"
+                >
+                  <Undo2 className="w-4 h-4" />
+                  Undo
+                </button>
+              )}
+              {settings.showRedo && (
+                <button
+                  onClick={redo}
+                  className="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 transition-colors"
+                >
+                  <Redo2 className="w-4 h-4" />
+                  Redo
+                </button>
+              )}
             </div>
           </div>
         </div>

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { useSettings } from '../hooks/useSettings';
+
+export const SettingsPage: React.FC = () => {
+  const { settings, toggleUndo, toggleRedo } = useSettings();
+
+  return (
+    <div className="p-8 max-w-xl mx-auto">
+      <h2 className="text-2xl font-bold mb-6 text-center">Settings</h2>
+      <div className="space-y-4">
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={settings.showUndo}
+            onChange={toggleUndo}
+            className="w-4 h-4"
+          />
+          <span className="text-gray-800 dark:text-gray-200">Show Undo Button</span>
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={settings.showRedo}
+            onChange={toggleRedo}
+            className="w-4 h-4"
+          />
+          <span className="text-gray-800 dark:text-gray-200">Show Redo Button</span>
+        </label>
+      </div>
+    </div>
+  );
+};
+

--- a/src/components/StatsTracker.tsx
+++ b/src/components/StatsTracker.tsx
@@ -15,6 +15,7 @@ import {
   Hand,
 } from 'lucide-react';
 import { formatTime } from '../utils/format';
+import { useSettings } from '../hooks/useSettings';
 
 interface StatsTrackerProps {
   gameState: GameState;
@@ -43,6 +44,7 @@ export const StatsTracker: React.FC<StatsTrackerProps> = ({
   redo,
 }) => {
   const { homeTeam, awayTeam, ballPossession } = gameState;
+  const { settings } = useSettings();
   const homePlayers = homeTeam.players ?? [];
   const awayPlayers = awayTeam.players ?? [];
 
@@ -261,18 +263,22 @@ export const StatsTracker: React.FC<StatsTrackerProps> = ({
                 </div>
               </div>
               <div className="flex gap-2">
-                <button
-                  onClick={undo}
-                  className="inline-flex items-center gap-2 px-3 py-1 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 transition-colors"
-                >
-                  <Undo2 className="w-4 h-4" /> Undo
-                </button>
-                <button
-                  onClick={redo}
-                  className="inline-flex items-center gap-2 px-3 py-1 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 transition-colors"
-                >
-                  <Redo2 className="w-4 h-4" /> Redo
-                </button>
+                {settings.showUndo && (
+                  <button
+                    onClick={undo}
+                    className="inline-flex items-center gap-2 px-3 py-1 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 transition-colors"
+                  >
+                    <Undo2 className="w-4 h-4" /> Undo
+                  </button>
+                )}
+                {settings.showRedo && (
+                  <button
+                    onClick={redo}
+                    className="inline-flex items-center gap-2 px-3 py-1 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 transition-colors"
+                  >
+                    <Redo2 className="w-4 h-4" /> Redo
+                  </button>
+                )}
               </div>
             </div>
           </div>

--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -1,0 +1,55 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+interface Settings {
+  showUndo: boolean;
+  showRedo: boolean;
+}
+
+interface SettingsContextType {
+  settings: Settings;
+  toggleUndo: () => void;
+  toggleRedo: () => void;
+}
+
+const defaultSettings: Settings = { showUndo: true, showRedo: true };
+
+const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
+
+export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [settings, setSettings] = useState<Settings>(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('settings');
+      if (stored) {
+        try {
+          const parsed = JSON.parse(stored);
+          return { ...defaultSettings, ...parsed } as Settings;
+        } catch {
+          // ignore parse errors
+        }
+      }
+    }
+    return defaultSettings;
+  });
+
+  useEffect(() => {
+    localStorage.setItem('settings', JSON.stringify(settings));
+  }, [settings]);
+
+  const toggleUndo = () => setSettings(s => ({ ...s, showUndo: !s.showUndo }));
+  const toggleRedo = () => setSettings(s => ({ ...s, showRedo: !s.showRedo }));
+
+  return (
+    <SettingsContext.Provider value={{ settings, toggleUndo, toggleRedo }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+};
+
+export const useSettings = () => {
+  const context = useContext(SettingsContext);
+  if (!context) {
+    throw new Error('useSettings must be used within SettingsProvider');
+  }
+  return context;
+};
+


### PR DESCRIPTION
## Summary
- add settings context and dedicated settings page
- allow hiding undo/redo buttons
- link settings into main app routing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893b1ac70ec832db970462d40a4b3d2