### PR TITLE
feat: add streaming control panel view

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -15,8 +15,10 @@ import {
   Undo2,
   Redo2,
   Settings,
+  Cast,
 } from 'lucide-react';
 import { useSettings } from '../hooks/useSettings';
+import StreamingControlPanel from './StreamingControlPanel';
 
 interface DashboardProps {
   gameState: GameState;
@@ -52,6 +54,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
   const [activeTab, setActiveTab] = useState<'teams' | 'timer' | 'format'>('teams');
   const tabs = ['teams', 'timer', 'format'] as const;
   const { settings } = useSettings();
+  const [currentView, setCurrentView] = useState<'dashboard' | 'stream'>('dashboard');
 
   const [homeLogoError, setHomeLogoError] = useState('');
   const [awayLogoError, setAwayLogoError] = useState('');
@@ -170,6 +173,13 @@ export const Dashboard: React.FC<DashboardProps> = ({
                 Streaming Overlay
               </button>
               <button
+                onClick={() => setCurrentView(currentView === 'stream' ? 'dashboard' : 'stream')}
+                className="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors"
+              >
+                <Cast className="w-4 h-4" />
+                Streaming Control
+              </button>
+              <button
                 onClick={() => onViewChange('stats')}
                 className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
               >
@@ -207,27 +217,31 @@ export const Dashboard: React.FC<DashboardProps> = ({
       </div>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <MatchSummary gameState={gameState} />
-        {/* Navigation Tabs */}
-        <div className="mb-8">
-          <div className="border-b border-gray-200">
-            <nav className="-mb-px flex space-x-8">
-              {tabs.map((tab) => (
-                <button
-                  key={tab}
-                  onClick={() => setActiveTab(tab)}
-                  className={`py-2 px-1 border-b-2 font-medium text-sm capitalize transition-colors ${
-                    activeTab === tab
-                      ? 'border-green-500 text-green-600'
-                      : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
-                  }`}
-                >
-                  {tab === 'format' ? 'Game Format' : tab}
-                </button>
-              ))}
-            </nav>
-          </div>
-        </div>
+        {currentView === 'stream' ? (
+          <StreamingControlPanel />
+        ) : (
+          <>
+            <MatchSummary gameState={gameState} />
+            {/* Navigation Tabs */}
+            <div className="mb-8">
+              <div className="border-b border-gray-200">
+                <nav className="-mb-px flex space-x-8">
+                  {tabs.map((tab) => (
+                    <button
+                      key={tab}
+                      onClick={() => setActiveTab(tab)}
+                      className={`py-2 px-1 border-b-2 font-medium text-sm capitalize transition-colors ${
+                        activeTab === tab
+                          ? 'border-green-500 text-green-600'
+                          : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                      }`}
+                    >
+                      {tab === 'format' ? 'Game Format' : tab}
+                    </button>
+                  ))}
+                </nav>
+              </div>
+            </div>
 
         {/* Teams Tab */}
         {activeTab === 'teams' && (
@@ -610,7 +624,8 @@ export const Dashboard: React.FC<DashboardProps> = ({
             onPresetChange={changeGamePreset}
           />
         )}
-
+          </>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add Streaming Control header button to Dashboard
- manage local `stream` view state and render `StreamingControlPanel`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894d1165900832daf779610a4d22a52