### PR TITLE
feat: add streaming control panel

### DIFF
--- a/src/components/StreamingControlPanel.tsx
+++ b/src/components/StreamingControlPanel.tsx
@@ -1,31 +1,36 @@
 import React, { useEffect, useState } from 'react';
 
+/**
+ * Simple panel to configure RTMP streaming credentials.
+ *
+ * Values are persisted to localStorage so the form remembers
+ * previous input on reload. A helper button concatenates the
+ * configured URL and stream key for easy sharing.
+ */
 const StreamingControlPanel: React.FC = () => {
   const [rtmpUrl, setRtmpUrl] = useState('');
   const [streamKey, setStreamKey] = useState('');
-  const [isValid, setIsValid] = useState(true);
+  const [isValidUrl, setIsValidUrl] = useState(true);
 
+  // Load any stored values on mount
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      setRtmpUrl(window.localStorage.getItem('rtmp.url') ?? '');
-      setStreamKey(window.localStorage.getItem('rtmp.key') ?? '');
-    }
+    if (typeof window === 'undefined') return;
+    const storedUrl = window.localStorage.getItem('rtmp.url') ?? '';
+    const storedKey = window.localStorage.getItem('rtmp.key') ?? '';
+    setRtmpUrl(storedUrl);
+    setStreamKey(storedKey);
+    setIsValidUrl(validateUrl(storedUrl));
   }, []);
 
+  // Persist changes to localStorage
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem('rtmp.url', rtmpUrl);
-    }
-  }, [rtmpUrl]);
-
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem('rtmp.key', streamKey);
-    }
-  }, [streamKey]);
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem('rtmp.url', rtmpUrl);
+    window.localStorage.setItem('rtmp.key', streamKey);
+  }, [rtmpUrl, streamKey]);
 
   const validateUrl = (url: string) => {
-    if (!url) return false;
+    if (!url.trim()) return false;
     try {
       new URL(url);
       return true;
@@ -37,20 +42,19 @@ const StreamingControlPanel: React.FC = () => {
   const handleUrlChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setRtmpUrl(value);
-    setIsValid(validateUrl(value));
+    setIsValidUrl(validateUrl(value));
   };
 
-  const copyLink = async () => {
-    const link = streamKey
-      ? `${rtmpUrl.replace(/\/$/, '')}/${streamKey}`
-      : rtmpUrl;
+  const handleCopy = async () => {
+    const base = rtmpUrl.replace(/\/$/, '');
+    const link = streamKey ? `${base}/${streamKey}` : base;
     await navigator.clipboard.writeText(link);
   };
 
   return (
     <form className="p-4 space-y-4">
       <div>
-        <label className="block mb-1 font-medium" htmlFor="rtmpUrl">
+        <label htmlFor="rtmpUrl" className="block mb-1 font-medium">
           RTMP URL
         </label>
         <input
@@ -60,12 +64,13 @@ const StreamingControlPanel: React.FC = () => {
           onChange={handleUrlChange}
           className="w-full border rounded px-2 py-1"
         />
-        {!isValid && (
-          <p className="text-sm text-red-600 mt-1">Please enter a valid URL.</p>
+        {!isValidUrl && (
+          <p className="mt-1 text-sm text-red-600">Please enter a valid URL.</p>
         )}
       </div>
+
       <div>
-        <label className="block mb-1 font-medium" htmlFor="streamKey">
+        <label htmlFor="streamKey" className="block mb-1 font-medium">
           Stream Key (optional)
         </label>
         <input
@@ -76,10 +81,11 @@ const StreamingControlPanel: React.FC = () => {
           className="w-full border rounded px-2 py-1"
         />
       </div>
+
       <button
         type="button"
-        onClick={copyLink}
-        disabled={!validateUrl(rtmpUrl)}
+        onClick={handleCopy}
+        disabled={!isValidUrl}
         className="px-4 py-2 bg-indigo-600 text-white rounded disabled:opacity-50"
       >
         Copy link


### PR DESCRIPTION
## Summary
- add RTMP streaming control panel with localStorage persistence

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894cf588a44832d861b71ada13fb20f