### PR TITLE
feat: integrate RTMP streaming controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { BrowserRouter, Routes, Route, Navigate, useNavigate } from 'react-router-dom';
 import { useGameState } from './hooks/useGameState';
 import { useTheme } from './hooks/useTheme';
@@ -27,6 +27,7 @@ interface MainLayoutProps {
 
 const MainLayout: React.FC<MainLayoutProps> = ({ gameState, theme, toggleTheme }) => {
   const navigate = useNavigate();
+  const [overlayRef, setOverlayRef] = useState<HTMLElement | null>(null);
 
   const handleViewChange = (view: ViewMode) => {
     navigate(`/${view}`);
@@ -41,7 +42,7 @@ const MainLayout: React.FC<MainLayoutProps> = ({ gameState, theme, toggleTheme }
 
   const OverlayView: React.FC = () => (
     <div className="relative min-h-screen bg-transparent">
-      <Overlay gameState={gameState.gameState} />
+      <Overlay gameState={gameState.gameState} onReady={setOverlayRef} />
       <ControlPanelButton onClick={() => navigate('/dashboard')} />
     </div>
   );
@@ -95,6 +96,7 @@ const MainLayout: React.FC<MainLayoutProps> = ({ gameState, theme, toggleTheme }
               addPlayer={gameState.addPlayer}
               removePlayer={gameState.removePlayer}
               onViewChange={handleViewChange}
+              overlayRef={overlayRef}
             />
           }
         />

--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { GameState } from '../types';
 import { Crown } from 'lucide-react';
 import { formatTime, isWinning } from '../utils/format';
@@ -7,16 +7,29 @@ import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 interface OverlayProps {
   gameState?: GameState | null;
   showStats?: boolean;
+  /**
+   * Optional callback fired once the overlay container is rendered.
+   * Provides a ref to the root element so it can be captured for
+   * streaming or other external manipulations.
+   */
+  onReady?: (element: HTMLDivElement | null) => void;
 }
 
-export const Overlay: React.FC<OverlayProps> = ({ gameState, showStats = false }) => {
+export const Overlay: React.FC<OverlayProps> = ({ gameState, showStats = false, onReady }) => {
   const shouldReduceMotion = useReducedMotion();
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    onReady?.(containerRef.current);
+    return () => onReady?.(null);
+  }, [onReady]);
+
   if (!gameState) return null;
 
   const { homeTeam, awayTeam, time } = gameState;
 
   return (
-    <div className="fixed inset-0 pointer-events-none">
+    <div ref={containerRef} className="fixed inset-0 pointer-events-none">
       {/* Top Bar Overlay */}
       <motion.div
         className="absolute top-0 left-0 right-0 flex justify-center items-center h-16 z-50"

--- a/src/components/StreamingControlPanel.tsx
+++ b/src/components/StreamingControlPanel.tsx
@@ -1,33 +1,33 @@
 import React, { useEffect, useState } from 'react';
 
+interface StreamingControlPanelProps {
+  rtmpUrl: string;
+  streamKey: string;
+  onUrlChange: (url: string) => void;
+  onKeyChange: (key: string) => void;
+  onStart: () => void;
+  onStop: () => void;
+  isStreaming: boolean;
+}
+
 /**
- * Simple panel to configure RTMP streaming credentials.
- *
- * Values are persisted to localStorage so the form remembers
- * previous input on reload. A helper button concatenates the
- * configured URL and stream key for easy sharing.
+ * Panel to configure RTMP streaming credentials and control the stream.
+ * Values are provided by the parent component and persisted there.
  */
-const StreamingControlPanel: React.FC = () => {
-  const [rtmpUrl, setRtmpUrl] = useState('');
-  const [streamKey, setStreamKey] = useState('');
+const StreamingControlPanel: React.FC<StreamingControlPanelProps> = ({
+  rtmpUrl,
+  streamKey,
+  onUrlChange,
+  onKeyChange,
+  onStart,
+  onStop,
+  isStreaming,
+}) => {
   const [isValidUrl, setIsValidUrl] = useState(true);
 
-  // Load any stored values on mount
   useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const storedUrl = window.localStorage.getItem('rtmp.url') ?? '';
-    const storedKey = window.localStorage.getItem('rtmp.key') ?? '';
-    setRtmpUrl(storedUrl);
-    setStreamKey(storedKey);
-    setIsValidUrl(validateUrl(storedUrl));
-  }, []);
-
-  // Persist changes to localStorage
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    window.localStorage.setItem('rtmp.url', rtmpUrl);
-    window.localStorage.setItem('rtmp.key', streamKey);
-  }, [rtmpUrl, streamKey]);
+    setIsValidUrl(validateUrl(rtmpUrl));
+  }, [rtmpUrl]);
 
   const validateUrl = (url: string) => {
     if (!url.trim()) return false;
@@ -41,7 +41,7 @@ const StreamingControlPanel: React.FC = () => {
 
   const handleUrlChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
-    setRtmpUrl(value);
+    onUrlChange(value);
     setIsValidUrl(validateUrl(value));
   };
 
@@ -77,19 +77,37 @@ const StreamingControlPanel: React.FC = () => {
           id="streamKey"
           type="text"
           value={streamKey}
-          onChange={e => setStreamKey(e.target.value)}
+          onChange={e => onKeyChange(e.target.value)}
           className="w-full border rounded px-2 py-1"
         />
       </div>
 
-      <button
-        type="button"
-        onClick={handleCopy}
-        disabled={!isValidUrl}
-        className="px-4 py-2 bg-indigo-600 text-white rounded disabled:opacity-50"
-      >
-        Copy link
-      </button>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={handleCopy}
+          disabled={!isValidUrl}
+          className="px-4 py-2 bg-indigo-600 text-white rounded disabled:opacity-50"
+        >
+          Copy link
+        </button>
+        <button
+          type="button"
+          onClick={onStart}
+          disabled={!isValidUrl || isStreaming}
+          className="px-4 py-2 bg-green-600 text-white rounded disabled:opacity-50"
+        >
+          Start
+        </button>
+        <button
+          type="button"
+          onClick={onStop}
+          disabled={!isStreaming}
+          className="px-4 py-2 bg-red-600 text-white rounded disabled:opacity-50"
+        >
+          Stop
+        </button>
+      </div>
     </form>
   );
 };


### PR DESCRIPTION
## Summary
- expose overlay container via `onReady` callback
- wire RTMP streaming hook in dashboard and pass stored settings
- add start/stop controls to streaming panel

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894f0269bd0832d8c1b9efa4387d21f