### PR TITLE
Guard against missing clipboard API

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,8 @@ Key interface elements such as the live indicator and score updates use smooth a
 ## Progressive Web App
 On supported browsers, use the "Install" or "Add to Home Screen" option to install the app. Once installed, it can run offline and launch in a standalone window.
 
+## Manual QA
+- Disable clipboard access in your browser or run the app in an environment without the Clipboard API.
+- Open the streaming control panel and click **Copy link**.
+- An alert should appear indicating the clipboard feature is unavailable instead of copying text.
+

--- a/src/components/StreamingControlPanel.tsx
+++ b/src/components/StreamingControlPanel.tsx
@@ -48,7 +48,17 @@ const StreamingControlPanel: React.FC = () => {
   const handleCopy = async () => {
     const base = rtmpUrl.replace(/\/$/, '');
     const link = streamKey ? `${base}/${streamKey}` : base;
-    await navigator.clipboard.writeText(link);
+    const clipboard =
+      typeof navigator !== 'undefined' && navigator.clipboard
+        ? navigator.clipboard
+        : null;
+    if (!clipboard) {
+      if (typeof window !== 'undefined') {
+        window.alert('Clipboard API is not available in this environment');
+      }
+      return;
+    }
+    await clipboard.writeText(link);
   };
 
   return (


### PR DESCRIPTION
## Summary
- Check for `navigator.clipboard` before copying stream link
- Add manual QA steps for clipboard fallback alert

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894f2f02e88832da2702bb5767fc0d1