### PR TITLE
Keep overlay mounted for persistent streaming reference

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -37,10 +37,10 @@ interface DashboardProps {
     view: 'scoreboard' | 'dashboard' | 'overlay' | 'stats' | 'settings'
   ) => void;
   /**
-   * Reference to the overlay container element. Provided when the overlay
-   * view is mounted so streaming can capture the element.
+   * Reference to the overlay container element. Always present so
+   * streaming can capture the element regardless of the current view.
    */
-  overlayRef?: HTMLElement | null;
+  overlayRef: HTMLElement | null;
 }
 
 export const Dashboard: React.FC<DashboardProps> = ({
@@ -65,7 +65,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
 
   const [rtmpUrl, setRtmpUrl] = useState('');
   const [streamKey, setStreamKey] = useState('');
-  const { start, stop, isStreaming } = useRtmpStream(overlayRef ?? null, rtmpUrl, streamKey);
+  const { start, stop, isStreaming } = useRtmpStream(overlayRef, rtmpUrl, streamKey);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;


### PR DESCRIPTION
## Summary
- Keep Overlay component mounted at all times and hide it when not viewing the overlay route
- Expose persistent overlay reference to Dashboard and forward it to useRtmpStream

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894fa8cc78c832d86cefa49fcc4c95c