### PR TITLE
feat: stream overlay chunks via websocket

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -65,7 +65,13 @@ export const Dashboard: React.FC<DashboardProps> = ({
 
   const [rtmpUrl, setRtmpUrl] = useState('');
   const [streamKey, setStreamKey] = useState('');
-  const { start, stop, isStreaming } = useRtmpStream(overlayRef, rtmpUrl, streamKey);
+  const {
+    start,
+    stop,
+    isStreaming,
+    connectionState,
+    error: streamError,
+  } = useRtmpStream(overlayRef, rtmpUrl, streamKey);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -251,6 +257,8 @@ export const Dashboard: React.FC<DashboardProps> = ({
             onStart={start}
             onStop={stop}
             isStreaming={isStreaming}
+            connectionState={connectionState}
+            streamError={streamError}
           />
         ) : (
           <>

--- a/src/components/StreamingControlPanel.tsx
+++ b/src/components/StreamingControlPanel.tsx
@@ -8,6 +8,8 @@ interface StreamingControlPanelProps {
   onStart: () => Promise<void> | void;
   onStop: () => void;
   isStreaming: boolean;
+  connectionState: 'disconnected' | 'connecting' | 'connected' | 'error';
+  streamError?: string | null;
 }
 
 /**
@@ -22,9 +24,11 @@ const StreamingControlPanel: React.FC<StreamingControlPanelProps> = ({
   onStart,
   onStop,
   isStreaming,
+  connectionState,
+  streamError,
 }) => {
   const [isValidUrl, setIsValidUrl] = useState(true);
-  const [error, setError] = useState('');
+  const [localError, setLocalError] = useState('');
 
   useEffect(() => {
     setIsValidUrl(validateUrl(rtmpUrl));
@@ -64,15 +68,15 @@ const StreamingControlPanel: React.FC<StreamingControlPanelProps> = ({
 
   const handleStart = async () => {
     if (!isValidUrl) {
-      setError('Please enter a valid URL.');
+      setLocalError('Please enter a valid URL.');
       return;
     }
-    setError('');
+    setLocalError('');
     try {
       await onStart();
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to start stream';
-      setError(`Failed to connect: ${message}`);
+      setLocalError(`Failed to connect: ${message}`);
     }
   };
 
@@ -136,11 +140,23 @@ const StreamingControlPanel: React.FC<StreamingControlPanelProps> = ({
 
       <p className="text-sm mt-2">
         Status{' '}
-        <span className={isStreaming ? 'text-green-600' : 'text-gray-600'}>
-          {isStreaming ? 'Streaming…' : 'Disconnected'}
+        <span
+          className={
+            connectionState === 'connected'
+              ? 'text-green-600'
+              : connectionState === 'connecting'
+              ? 'text-yellow-600'
+              : connectionState === 'error'
+              ? 'text-red-600'
+              : 'text-gray-600'
+          }
+        >
+          {connectionState}
         </span>
       </p>
-      {error && <p className="text-sm text-red-600">{error}</p>}
+      {(localError || streamError) && (
+        <p className="text-sm text-red-600">{streamError || localError}</p>
+      )}
 
       <div className="mt-4 space-y-1 text-sm text-gray-700">
         <p>


### PR DESCRIPTION
## Summary
- stream MediaRecorder chunks through WebSocket with ffmpeg.wasm encoding
- track connection state and expose errors for continuous streaming
- surface streaming status in dashboard control panel

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689573b169fc832da4da26ea5e573277