### PR TITLE
docs: add overlay troubleshooting guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ To operate the timer from another device, open `/#/remote` on a device connected
 ### Browser Source Overlay
 Load `/#/overlay` in OBS, Yololiv, or any browser source to display a transparent scoreboard and optional stats without any control UI.
 
+### Common Overlay Issues
+
+- **Browser compatibility for `BroadcastChannel`**: The overlay relies on the `BroadcastChannel` API to sync state between windows. Some browsers (such as older Safari versions) do not support this API. In those cases, include a polyfill like [`broadcast-channel`](https://github.com/pubkey/broadcast-channel) or fall back to `localStorage` events for communication.
+- **Ensure multiple windows share the same origin**: Both the control dashboard and the overlay must be served from the same protocol, domain, and port. Opening one in a different origin (including `file://` URLs) prevents updates.
+- **Verify updates via console logs**: Open the developer console in each window. The overlay logs messages when it receives updates, which helps confirm that communication is working.
+
+If `BroadcastChannel` isn't available, import a polyfill or adapt the overlay to use `localStorage` events as a lightweight fallback.
+
 ### Animations
 Key interface elements such as the live indicator and score updates use smooth animations to improve readability. These animations are powered by Tailwind CSS utility classes.
 


### PR DESCRIPTION
## Summary
- document common overlay issues around BroadcastChannel support and window origin
- suggest polyfills or fallbacks when BroadcastChannel isn't available

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895afcb9ea4832d964c3991cba94b8a