### PR TITLE
Respect base path for streaming overlay

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -140,7 +140,10 @@ export const Dashboard: React.FC<DashboardProps> = ({
       updateTime(newMinutes, newSeconds);
     }
   };
-
+  const overlayUrl =
+    typeof window !== 'undefined'
+      ? `${window.location.origin}${import.meta.env.BASE_URL}overlay`
+      : '/overlay';
 
   return (
     <div className="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
@@ -160,7 +163,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
               <button
                 onClick={() =>
                   typeof window !== 'undefined' &&
-                  window.open('/overlay', '_blank')
+                  window.open(overlayUrl, '_blank')
                 }
                 className="inline-flex items-center gap-2 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors"
               >


### PR DESCRIPTION
## Summary
- Build overlay URL using `window.location.origin` and `import.meta.env.BASE_URL` to work under subdirectory deployments
- Use the computed URL when opening the streaming overlay window

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895afcacc48832db7ed5bf543a456fa