### PR TITLE
docs: clarify overlay route path

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ Navigate between the dashboard, scoreboard, stats tracker, and overlay views usi
 To operate the timer from another device, open `/#/remote` on a device connected to the same network.
 
 ### Browser Source Overlay
-Load `/#/overlay` in OBS, Yololiv, or any browser source to display a transparent scoreboard and optional stats without any control UI.
+Load `/overlay` in OBS, Yololiv, or any browser source to display a transparent scoreboard and optional stats without any control UI.
+
+If the application uses a hash-based router, the overlay path will appear as `/#/overlay` instead.
 
 ### Animations
 Key interface elements such as the live indicator and score updates use smooth animations to improve readability. These animations are powered by Tailwind CSS utility classes.


### PR DESCRIPTION
## Summary
- document overlay at `/overlay` for browser sources
- note hash-based router path `/#/overlay`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895afc9ffec832dae1db308a31f2739