### PR TITLE
Separate overlay routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ A modern React + TypeScript scoreboard for tracking futsal matches with a polish
 The UI automatically follows your system theme. Switch your operating system or browser to dark mode to experience the darker palette.
 
 ### Routes
-Navigate between the dashboard, scoreboard, stats tracker, and overlay views using the on-screen controls or by visiting the respective routes (`/dashboard`, `/scoreboard`, `/stats`, `/overlay`).
+Navigate between the dashboard, scoreboard, stats tracker, and overlay views using the on-screen controls or by visiting the respective routes (`/dashboard`, `/scoreboard`, `/stats`, `/overlay`, `/overlay/stats`).
 
 To operate the timer from another device, open `/#/remote` on a device connected to the same network.
 
 ### Browser Source Overlay
-Load `/#/overlay` in OBS, Yololiv, or any browser source to display a transparent scoreboard and optional stats without any control UI.
+Load `/#/overlay` in OBS, Yololiv, or any browser source to display a transparent scoreboard or `/#/overlay/stats` to include team statistics, both without any control UI.
 
 ### Animations
 Key interface elements such as the live indicator and score updates use smooth animations to improve readability. These animations are powered by Tailwind CSS utility classes.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,9 +108,12 @@ const AppContent: React.FC = () => {
     <BrowserRouter>
       <Routes>
         <Route path="/remote" element={<RemoteControl />} />
-        <Route path="/overlay" element={<Overlay gameState={gameState.gameState} />} />
         <Route
           path="/overlay"
+          element={<Overlay gameState={gameState.gameState} />}
+        />
+        <Route
+          path="/overlay/stats"
           element={<Overlay gameState={gameState.gameState} showStats />}
         />
         <Route

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -160,7 +160,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
               <button
                 onClick={() =>
                   typeof window !== 'undefined' &&
-                  window.open('/overlay', '_blank')
+                  window.open('/overlay/stats', '_blank')
                 }
                 className="inline-flex items-center gap-2 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors"
               >


### PR DESCRIPTION
## Summary
- Split overlay route into `/overlay` and `/overlay/stats` for stats view
- Use new stats overlay path in dashboard overlay launcher
- Document new overlay paths in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895afc8a9e4832db1d7f4c7da5f8c66