### PR TITLE
Add Vitest script and refactor layout and theme hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run --environment jsdom"
   },
   "dependencies": {
     "framer-motion": "^11.0.0",
@@ -30,6 +31,9 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^1.6.0",
+    "@testing-library/react": "^16.0.0",
+    "jsdom": "^24.0.0"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,27 +17,25 @@ type ViewMode =
   | 'stats'
   | 'settings';
 
-interface MainLayoutProps {
-  gameState: ReturnType<typeof useGameState>;
-  theme: string;
-  toggleTheme: () => void;
+type GameStateType = ReturnType<typeof useGameState>;
+
+interface ViewProps {
+  gameState: GameStateType;
 }
 
-const MainLayout: React.FC<MainLayoutProps> = ({ gameState, theme, toggleTheme }) => {
+const ScoreboardView: React.FC<ViewProps> = ({ gameState }) => {
   const navigate = useNavigate();
-
-  const handleViewChange = (view: ViewMode) => {
-    navigate(`/${view}`);
-  };
-
-  const ScoreboardView: React.FC = () => (
+  return (
     <div className="relative">
       <Scoreboard gameState={gameState.gameState} />
       <ControlPanelButton onClick={() => navigate('/dashboard')} />
     </div>
   );
+};
 
-  const StatsView: React.FC = () => (
+const StatsView: React.FC<ViewProps> = ({ gameState }) => {
+  const navigate = useNavigate();
+  return (
     <div className="relative">
       <StatsTracker
         gameState={gameState.gameState}
@@ -52,8 +50,11 @@ const MainLayout: React.FC<MainLayoutProps> = ({ gameState, theme, toggleTheme }
       <ControlPanelButton onClick={() => navigate('/dashboard')} />
     </div>
   );
+};
 
-  const SettingsView: React.FC = () => (
+const SettingsView: React.FC<ViewProps> = ({ gameState }) => {
+  const navigate = useNavigate();
+  return (
     <div className="relative">
       <SettingsPage
         gameState={gameState.gameState}
@@ -65,6 +66,20 @@ const MainLayout: React.FC<MainLayoutProps> = ({ gameState, theme, toggleTheme }
       <ControlPanelButton onClick={() => navigate('/dashboard')} />
     </div>
   );
+};
+
+interface MainLayoutProps {
+  gameState: GameStateType;
+  theme: string;
+  toggleTheme: () => void;
+}
+
+const MainLayout: React.FC<MainLayoutProps> = ({ gameState, theme, toggleTheme }) => {
+  const navigate = useNavigate();
+
+  const handleViewChange = (view: ViewMode) => {
+    navigate(`/${view}`);
+  };
 
   return (
     <div className="App">
@@ -89,9 +104,9 @@ const MainLayout: React.FC<MainLayoutProps> = ({ gameState, theme, toggleTheme }
             />
           }
         />
-        <Route path="/scoreboard" element={<ScoreboardView />} />
-        <Route path="/stats" element={<StatsView />} />
-        <Route path="/settings" element={<SettingsView />} />
+        <Route path="/scoreboard" element={<ScoreboardView gameState={gameState} />} />
+        <Route path="/stats" element={<StatsView gameState={gameState} />} />
+        <Route path="/settings" element={<SettingsView gameState={gameState} />} />
         <Route path="/" element={<Navigate to="/dashboard" replace />} />
         <Route path="*" element={<Navigate to="/dashboard" replace />} />
       </Routes>

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -10,22 +10,34 @@ type Theme = 'light' | 'dark';
 export function useTheme() {
   const [theme, setTheme] = useState<Theme>(() => {
     if (typeof window !== 'undefined') {
-      const stored = localStorage.getItem('theme') as Theme | null;
-      if (stored === 'dark' || stored === 'light') {
-        return stored;
+      try {
+        const stored = window.localStorage.getItem('theme') as Theme | null;
+        if (stored === 'dark' || stored === 'light') {
+          return stored;
+        }
+      } catch {
+        /* ignore */
       }
     }
     return 'light';
   });
 
   useEffect(() => {
-    const root = document.documentElement;
-    if (theme === 'dark') {
-      root.classList.add('dark');
-    } else {
-      root.classList.remove('dark');
+    if (typeof document !== 'undefined') {
+      const root = document.documentElement;
+      if (theme === 'dark') {
+        root.classList.add('dark');
+      } else {
+        root.classList.remove('dark');
+      }
     }
-    localStorage.setItem('theme', theme);
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage.setItem('theme', theme);
+      } catch {
+        /* ignore */
+      }
+    }
   }, [theme]);
 
   const toggleTheme = () => setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));


### PR DESCRIPTION
## Summary
- add vitest-based `npm test` script and development dependencies
- refactor layout by extracting inline views from `MainLayout`
- guard `useTheme` against missing `localStorage`

## Testing
- `npm run lint`
- `npm test` *(fails: vitest: not found)*
- `npm run build`
- `npx browserslist@latest --update-db` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689625dd15c8832d98e9a1453be27aef