### PR TITLE
Allow setting starting ball possession

### DIFF
--- a/src/components/StatsTracker.tsx
+++ b/src/components/StatsTracker.tsx
@@ -324,7 +324,7 @@ export const StatsTracker: React.FC<StatsTrackerProps> = ({
                 {ballPossession === 'home' ? homeTeam.name : awayTeam.name}
               </div>
               <div className="mt-2 text-xs text-gray-500 dark:text-gray-400">
-                Press A/1 for Home, D/2 for Away (only when timer running)
+                Press A/1 for Home, D/2 for Away
               </div>
             </div>
 

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -323,12 +323,17 @@ export const useGameState = () => {
 
   const switchBallPossession = useCallback((newTeam: 'home' | 'away') => {
     setGameState(prev => {
-      // Only allow possession switching when timer is running
+      const now = Date.now();
+
+      // If the timer isn't running yet, just update possession
       if (!prev.isRunning) {
-        return prev;
+        return {
+          ...prev,
+          ballPossession: newTeam,
+          possessionStartTime: now,
+        };
       }
 
-      const now = Date.now();
       const { updatedPossessionTime, homePossession, awayPossession } =
         calculatePossession(prev, now);
 


### PR DESCRIPTION
## Summary
- Let users switch ball possession before the timer starts to mark kickoff.
- Remove "timer running" restriction from possession hint in stats tracker.

## Testing
- `npm test` *(fails: useSettings must be used within SettingsProvider)*

------
https://chatgpt.com/codex/tasks/task_e_689632037a44832d9731068b827545a7