### PR TITLE
feat: add team sheet limits for football and futsal

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A modern React + TypeScript scoreboard for tracking futsal matches with a polish
 
 ## Feature Overview
 - Real-time game dashboard with configurable teams, timer, and match presets
+- Team sheet management with automatic player limits (5 starters + 9 subs for futsal, 11 starters + 12 subs for football)
 - Dark mode styling that adapts to system preferences
 - Animated transitions for scores, timer, and live indicators
 - Route-based views for dashboard, scoreboard, and statistics

--- a/src/hooks/useGameState.test.ts
+++ b/src/hooks/useGameState.test.ts
@@ -156,7 +156,7 @@ describe('useGameState player management', () => {
   it('removes player and adjusts team totals', () => {
     const { result } = renderHook(() => useGameState(), { legacyRoot: true });
     act(() => {
-      result.current.addPlayer('home', 'Test Player');
+      result.current.addPlayer('home', 'Test Player', 'starter');
     });
     const playerId = result.current.gameState.homeTeam.players[0].id;
 
@@ -180,6 +180,42 @@ describe('useGameState player management', () => {
   });
 });
 
+describe('team sheet limits', () => {
+  it('enforces futsal player limits', () => {
+    const { result } = renderHook(() => useGameState(), { legacyRoot: true });
+    act(() => {
+      for (let i = 0; i < 6; i++) {
+        result.current.addPlayer('home', `Starter${i}`, 'starter');
+      }
+      for (let i = 0; i < 10; i++) {
+        result.current.addPlayer('home', `Sub${i}`, 'substitute');
+      }
+    });
+    const starters = result.current.gameState.homeTeam.players.filter(p => p.role === 'starter');
+    const subs = result.current.gameState.homeTeam.players.filter(p => p.role === 'substitute');
+    expect(starters).toHaveLength(5);
+    expect(subs).toHaveLength(9);
+  });
+
+  it('enforces football player limits', () => {
+    const { result } = renderHook(() => useGameState(), { legacyRoot: true });
+    act(() => {
+      result.current.changeGamePreset(0);
+      for (let i = 0; i < 12; i++) {
+        result.current.addPlayer('home', `Starter${i}`, 'starter');
+      }
+      for (let i = 0; i < 13; i++) {
+        result.current.addPlayer('home', `Sub${i}`, 'substitute');
+      }
+    });
+    const starters = result.current.gameState.homeTeam.players.filter(p => p.role === 'starter');
+    const subs = result.current.gameState.homeTeam.players.filter(p => p.role === 'substitute');
+    expect(starters).toHaveLength(11);
+    expect(subs).toHaveLength(12);
+    expect(result.current.gameState.homeTeam.players).toHaveLength(23);
+  });
+});
+
 describe('foul tracking', () => {
   it('increments fouls when team stats receive cards', () => {
     const { result } = renderHook(() => useGameState(), { legacyRoot: true });
@@ -198,7 +234,7 @@ describe('foul tracking', () => {
   it('increments fouls when player receives cards', () => {
     const { result } = renderHook(() => useGameState(), { legacyRoot: true });
     act(() => {
-      result.current.addPlayer('home', 'Player');
+      result.current.addPlayer('home', 'Player', 'starter');
     });
     const playerId = result.current.gameState.homeTeam.players[0].id;
     act(() => {
@@ -213,7 +249,7 @@ describe('foul tracking', () => {
   it('reduces fouls when carded player is removed', () => {
     const { result } = renderHook(() => useGameState(), { legacyRoot: true });
     act(() => {
-      result.current.addPlayer('home', 'Player');
+      result.current.addPlayer('home', 'Player', 'starter');
     });
     const playerId = result.current.gameState.homeTeam.players[0].id;
     act(() => {

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -293,25 +293,45 @@ export const useGameState = () => {
   );
 
   const addPlayer = useCallback(
-    (team: 'home' | 'away', name: string, number?: number) => {
-      const newPlayer: Player = {
-        id: crypto.randomUUID(),
-        name,
-        number,
-        goals: 0,
-        yellowCards: 0,
-        redCards: 0,
-      };
-      setGameState(prev => ({
-        ...prev,
-        [team === 'home' ? 'homeTeam' : 'awayTeam']: {
-          ...prev[team === 'home' ? 'homeTeam' : 'awayTeam'],
-          players: [
-            ...prev[team === 'home' ? 'homeTeam' : 'awayTeam'].players,
-            newPlayer,
-          ],
-        },
-      }));
+    (
+      team: 'home' | 'away',
+      name: string,
+      role: 'starter' | 'substitute',
+      number?: number,
+    ) => {
+      setGameState(prev => {
+        const teamKey = team === 'home' ? 'homeTeam' : 'awayTeam';
+        const players = prev[teamKey].players;
+        const limits =
+          prev.gamePreset.type === 'football'
+            ? { starters: 11, substitutes: 12, total: 23 }
+            : { starters: 5, substitutes: 9, total: 14 };
+
+        const starterCount = players.filter(p => p.role === 'starter').length;
+        const subCount = players.filter(p => p.role === 'substitute').length;
+
+        if (players.length >= limits.total) return prev;
+        if (role === 'starter' && starterCount >= limits.starters) return prev;
+        if (role === 'substitute' && subCount >= limits.substitutes) return prev;
+
+        const newPlayer: Player = {
+          id: crypto.randomUUID(),
+          name,
+          number,
+          role,
+          goals: 0,
+          yellowCards: 0,
+          redCards: 0,
+        };
+
+        return {
+          ...prev,
+          [teamKey]: {
+            ...prev[teamKey],
+            players: [...players, newPlayer],
+          },
+        };
+      });
     },
     [setGameState],
   );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@ export interface Player {
   id: string;
   name: string;
   number?: number;
+  role: 'starter' | 'substitute';
   goals: number;
   yellowCards: number;
   redCards: number;


### PR DESCRIPTION
## Summary
- support starter/substitute roles in team sheets
- enforce player count limits for football (11+12) and futsal (5+9)
- document and test roster restrictions

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689739a20cfc832d8bded297b0ca3df6