### PR TITLE
Fix goal updating while timer running

### DIFF
--- a/src/hooks/useGameState.test.ts
+++ b/src/hooks/useGameState.test.ts
@@ -352,6 +352,7 @@ describe('possession switching', () => {
     });
     expect(result.current.gameState.ballPossession).toBe('home');
     expect(result.current.gameState.isRunning).toBe(false);
+    expect(result.current.gameState.awayTeam.score).toBe(1);
   });
 
   it('switches to opponent and pauses after a foul', () => {

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -209,16 +209,16 @@ export const useGameState = () => {
             possessionStartTime: now,
             totalPossessionTime: updatedPossessionTime,
             homeTeam: {
-              ...((teamKey === 'home' ? newTeam : prev.homeTeam) as Team),
+              ...(team === 'home' ? newTeam : prev.homeTeam),
               stats: {
-                ...((teamKey === 'home' ? newTeam : prev.homeTeam).stats),
+                ...((team === 'home' ? newTeam : prev.homeTeam).stats),
                 possession: homePossession,
               },
             },
             awayTeam: {
-              ...((teamKey === 'away' ? newTeam : prev.awayTeam) as Team),
+              ...(team === 'away' ? newTeam : prev.awayTeam),
               stats: {
-                ...((teamKey === 'away' ? newTeam : prev.awayTeam).stats),
+                ...((team === 'away' ? newTeam : prev.awayTeam).stats),
                 possession: awayPossession,
               },
             },


### PR DESCRIPTION
## Summary
- fix goal-scoring logic so scores update while the match timer is running
- add regression test for scoring during play

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68977777ff64832daea2e1397dd67fcc