### PR TITLE
feat: add scoreboard share link and theme toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter, Routes, Route, Navigate, useNavigate } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate, useNavigate, useLocation } from 'react-router-dom';
 import { useGameState } from './hooks/useGameState';
 import { useTheme } from './hooks/useTheme';
 import { Scoreboard } from './components/Scoreboard';
@@ -23,12 +23,16 @@ interface ViewProps {
   gameState: GameStateType;
 }
 
-const ScoreboardView: React.FC<ViewProps> = ({ gameState }) => {
+interface ScoreboardViewProps extends ViewProps {
+  embed?: boolean;
+}
+
+const ScoreboardView: React.FC<ScoreboardViewProps> = ({ gameState, embed }) => {
   const navigate = useNavigate();
   return (
     <div className="relative">
       <Scoreboard gameState={gameState.gameState} />
-      <ControlPanelButton onClick={() => navigate('/dashboard')} />
+      {!embed && <ControlPanelButton onClick={() => navigate('/dashboard')} />}
     </div>
   );
 };
@@ -52,7 +56,12 @@ const StatsView: React.FC<ViewProps> = ({ gameState }) => {
   );
 };
 
-const SettingsView: React.FC<ViewProps> = ({ gameState }) => {
+interface SettingsViewProps extends ViewProps {
+  theme: 'light' | 'dark';
+  toggleTheme: () => void;
+}
+
+const SettingsView: React.FC<SettingsViewProps> = ({ gameState, theme, toggleTheme }) => {
   const navigate = useNavigate();
   return (
     <div className="relative">
@@ -62,6 +71,8 @@ const SettingsView: React.FC<ViewProps> = ({ gameState }) => {
         updateTournamentName={gameState.updateTournamentName}
         resetGame={gameState.resetGame}
         updateTeam={gameState.updateTeam}
+        theme={theme}
+        toggleTheme={toggleTheme}
       />
       <ControlPanelButton onClick={() => navigate('/dashboard')} />
     </div>
@@ -70,12 +81,15 @@ const SettingsView: React.FC<ViewProps> = ({ gameState }) => {
 
 interface MainLayoutProps {
   gameState: GameStateType;
-  theme: string;
+  theme: 'light' | 'dark';
   toggleTheme: () => void;
 }
 
 const MainLayout: React.FC<MainLayoutProps> = ({ gameState, theme, toggleTheme }) => {
   const navigate = useNavigate();
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+  const embed = params.get('embed') === 'true';
 
   const handleViewChange = (view: ViewMode) => {
     navigate(`/${view}`);
@@ -83,7 +97,7 @@ const MainLayout: React.FC<MainLayoutProps> = ({ gameState, theme, toggleTheme }
 
   return (
     <div className="App">
-      <ThemeToggle theme={theme} onToggle={toggleTheme} />
+      {!embed && <ThemeToggle theme={theme} onToggle={toggleTheme} />}
       <Routes>
         <Route
           path="/dashboard"
@@ -104,9 +118,9 @@ const MainLayout: React.FC<MainLayoutProps> = ({ gameState, theme, toggleTheme }
             />
           }
         />
-        <Route path="/scoreboard" element={<ScoreboardView gameState={gameState} />} />
+        <Route path="/scoreboard" element={<ScoreboardView gameState={gameState} embed={embed} />} />
         <Route path="/stats" element={<StatsView gameState={gameState} />} />
-        <Route path="/settings" element={<SettingsView gameState={gameState} />} />
+        <Route path="/settings" element={<SettingsView gameState={gameState} theme={theme} toggleTheme={toggleTheme} />} />
         <Route path="/" element={<Navigate to="/dashboard" replace />} />
         <Route path="*" element={<Navigate to="/dashboard" replace />} />
       </Routes>

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -14,6 +14,8 @@ interface SettingsPageProps {
     field: 'score' | 'fouls',
     value: number,
   ) => void;
+  theme: 'light' | 'dark';
+  toggleTheme: () => void;
 }
 
 const formatKey = (code: string) => {
@@ -28,6 +30,8 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
   updateTournamentName,
   resetGame,
   updateTeam,
+  theme,
+  toggleTheme,
 }) => {
   const {
     settings,
@@ -85,6 +89,8 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
 
   const cancelResetGame = () => setShowResetConfirm(false);
 
+  const scoreboardUrl = `${window.location.origin}/scoreboard?embed=true&theme=${theme}`;
+
   return (
     <div className="p-8 max-w-3xl mx-auto">
       <h2 className="text-2xl font-bold mb-6 text-center">Settings</h2>
@@ -107,6 +113,34 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
           />
           <span className="text-gray-800 dark:text-gray-200">Show Redo Button</span>
         </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={theme === 'dark'}
+            onChange={toggleTheme}
+            className="w-4 h-4"
+          />
+          <span className="text-gray-800 dark:text-gray-200">Dark Mode</span>
+        </label>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+            Scoreboard Link
+          </label>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              readOnly
+              value={scoreboardUrl}
+              className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-gray-100"
+            />
+            <button
+              onClick={() => navigator.clipboard.writeText(scoreboardUrl)}
+              className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+            >
+              Copy
+            </button>
+          </div>
+        </div>
       </div>
 
       <div className="space-y-6 mb-8">

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -11,6 +11,13 @@ export function useTheme() {
   const [theme, setTheme] = useState<Theme>(() => {
     if (typeof window !== 'undefined') {
       try {
+        // Allow theme to be specified via ?theme=dark|light in the URL
+        const params = new URLSearchParams(window.location.search);
+        const paramTheme = params.get('theme') as Theme | null;
+        if (paramTheme === 'dark' || paramTheme === 'light') {
+          return paramTheme;
+        }
+
         const stored = window.localStorage.getItem('theme') as Theme | null;
         if (stored === 'dark' || stored === 'light') {
           return stored;


### PR DESCRIPTION
## Summary
- allow `?theme=` in URL to force dark or light mode
- hide controls for `?embed=true` scoreboard links
- add dark mode toggle and copyable scoreboard link in settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897ac3feb48832db69b18d38a3ae39b