### PR TITLE
Fix scoreboard link to respect deployment base path

### DIFF
--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -89,7 +89,9 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
 
   const cancelResetGame = () => setShowResetConfirm(false);
 
-  const scoreboardUrl = `${window.location.origin}/scoreboard?embed=true&theme=${theme}`;
+  const { origin, pathname } = window.location;
+  const basePath = pathname.substring(0, pathname.lastIndexOf('/'));
+  const scoreboardUrl = `${origin}${basePath}/scoreboard?embed=true&theme=${theme}`;
 
   return (
     <div className="p-8 max-w-3xl mx-auto">


### PR DESCRIPTION
## Summary
- compute scoreboard URL using current pathname so copied link works from subdirectories and preserves theme

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897ae4f05c0832da46c3243689babc6