### PR TITLE
fix: define base path for scoreboard URL

### DIFF
--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -90,6 +90,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({
   const cancelResetGame = () => setShowResetConfirm(false);
 
   const { origin, pathname } = window.location;
+  const basePath = pathname.substring(0, pathname.lastIndexOf('/'));
   const scoreboardUrl = `${origin}${basePath}/scoreboard?embed=true&theme=${theme}`;
 
   return (


### PR DESCRIPTION
## Summary
- avoid ReferenceError in SettingsPage by defining `basePath` from current pathname

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68983a1ab0d8832daae3cd5ed46415fa