### PR TITLE
Add configurable scoreboard and control panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,8 @@ import { ControlPanelButton } from './components/ControlPanelButton';
 import { ThemeToggle } from './components/ThemeToggle';
 import { SettingsProvider } from './hooks/SettingsProvider';
 import { SettingsPage } from './components/SettingsPage';
+import { ScoreboardPage } from './components/ScoreboardPage';
+import { ScoreboardControlPanel } from './components/ScoreboardControlPanel';
 
 type ViewMode = 'dashboard' | 'stats' | 'settings';
 
@@ -111,6 +113,14 @@ const AppContent: React.FC = () => {
   return (
     <BrowserRouter>
       <Routes>
+        <Route
+          path="/scoreboard"
+          element={<ScoreboardPage gameState={gameState.gameState} />}
+        />
+        <Route
+          path="/scoreboard/control"
+          element={<ScoreboardControlPanel gameState={gameState.gameState} />}
+        />
         <Route
           path="/*"
           element={<MainLayout gameState={gameState} theme={theme} toggleTheme={toggleTheme} />}

--- a/src/components/Scoreboard.tsx
+++ b/src/components/Scoreboard.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { GameState } from '../types';
+import { getHalfName } from '../utils/gamePresets';
+
+interface ScoreboardProps {
+  gameState: GameState;
+  width?: number;
+  height?: number;
+}
+
+export const Scoreboard: React.FC<ScoreboardProps> = ({ gameState, width, height }) => {
+  const period = getHalfName(gameState.half, gameState.gamePreset, gameState.matchPhase);
+  const style: React.CSSProperties = {
+    width: width ? `${width}px` : undefined,
+    height: height ? `${height}px` : undefined,
+  };
+
+  return (
+    <div
+      className="flex items-center justify-between bg-black/70 text-white px-4 py-2 rounded"
+      style={style}
+    >
+      <div className="flex items-center gap-2">
+        {gameState.homeTeam.logo && (
+          <img
+            src={gameState.homeTeam.logo}
+            alt="Home logo"
+            className="h-8 w-8 object-contain"
+          />
+        )}
+        <span className="font-bold text-xl">{gameState.homeTeam.name}</span>
+      </div>
+      <div className="text-3xl font-bold">
+        {gameState.homeTeam.score} - {gameState.awayTeam.score}
+      </div>
+      <div className="flex items-center gap-2">
+        <span className="font-bold text-xl">{gameState.awayTeam.name}</span>
+        {gameState.awayTeam.logo && (
+          <img
+            src={gameState.awayTeam.logo}
+            alt="Away logo"
+            className="h-8 w-8 object-contain"
+          />
+        )}
+      </div>
+      <div className="flex flex-col items-end text-sm ml-4">
+        <span className="font-mono text-lg">
+          {String(gameState.time.minutes).padStart(2, '0')}:
+          {String(gameState.time.seconds).padStart(2, '0')}
+        </span>
+        <span>{period}</span>
+      </div>
+    </div>
+  );
+};

--- a/src/components/ScoreboardControlPanel.tsx
+++ b/src/components/ScoreboardControlPanel.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import { GameState } from '../types';
+import { Scoreboard } from './Scoreboard';
+import { ControlPanelButton } from './ControlPanelButton';
+import { useNavigate } from 'react-router-dom';
+
+interface Props {
+  gameState: GameState;
+}
+
+export const ScoreboardControlPanel: React.FC<Props> = ({ gameState }) => {
+  const navigate = useNavigate();
+  const [width, setWidth] = useState(800);
+  const [height, setHeight] = useState(200);
+
+  const url = `${window.location.origin}/scoreboard?width=${width}&height=${height}`;
+
+  return (
+    <div className="p-4 space-y-4 relative">
+      <ControlPanelButton onClick={() => navigate('/dashboard')} />
+      <div className="flex gap-4">
+        <label className="flex flex-col">
+          <span className="text-sm mb-1">Width</span>
+          <input
+            type="number"
+            value={width}
+            onChange={e => setWidth(parseInt(e.target.value) || 0)}
+            className="border rounded p-1 w-24"
+          />
+        </label>
+        <label className="flex flex-col">
+          <span className="text-sm mb-1">Height</span>
+          <input
+            type="number"
+            value={height}
+            onChange={e => setHeight(parseInt(e.target.value) || 0)}
+            className="border rounded p-1 w-24"
+          />
+        </label>
+      </div>
+      <div>
+        <label className="text-sm mb-1 block">Shareable Link</label>
+        <input type="text" readOnly value={url} className="border rounded p-2 w-full" />
+      </div>
+      <div className="border rounded p-4 bg-gray-100 dark:bg-gray-800">
+        <Scoreboard gameState={gameState} width={width} height={height} />
+      </div>
+    </div>
+  );
+};

--- a/src/components/ScoreboardPage.tsx
+++ b/src/components/ScoreboardPage.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { GameState } from '../types';
+import { useSearchParams } from 'react-router-dom';
+import { Scoreboard } from './Scoreboard';
+
+interface Props {
+  gameState: GameState;
+}
+
+export const ScoreboardPage: React.FC<Props> = ({ gameState }) => {
+  const [params] = useSearchParams();
+  const width = parseInt(params.get('width') || '800', 10);
+  const height = parseInt(params.get('height') || '200', 10);
+
+  return (
+    <div className="w-screen h-screen flex items-center justify-center bg-transparent">
+      <Scoreboard gameState={gameState} width={width} height={height} />
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- Add scoreboard overlay component with adjustable width/height
- Introduce scoreboard control panel to manage resolution and shareable link
- Expose scoreboard and control panel through dedicated routes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68989af8efb8832da9e3d136620505f3