### PR TITLE
Add navigation for scoreboard and control panel

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -12,6 +12,8 @@ import {
   Undo2,
   Redo2,
   Settings,
+  Monitor,
+  SlidersHorizontal,
 } from 'lucide-react';
 import { useSettings } from '../hooks/useSettings';
 import { GamePresetSelector } from './GamePresetSelector';
@@ -179,6 +181,20 @@ export const Dashboard: React.FC<DashboardProps> = ({
           <div className="flex justify-between items-center py-4">
             <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Futsal Control Dashboard</h1>
             <div className="flex gap-3">
+              <button
+                onClick={() => window.open('/scoreboard', '_blank')}
+                className="inline-flex items-center gap-2 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors"
+              >
+                <Monitor className="w-4 h-4" />
+                Scoreboard
+              </button>
+              <button
+                onClick={() => window.open('/scoreboard/control', '_blank')}
+                className="inline-flex items-center gap-2 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors"
+              >
+                <SlidersHorizontal className="w-4 h-4" />
+                Control Panel
+              </button>
               <button
                 onClick={() => onViewChange('stats')}
                 className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"

--- a/src/components/ScoreboardControlPanel.tsx
+++ b/src/components/ScoreboardControlPanel.tsx
@@ -41,6 +41,12 @@ export const ScoreboardControlPanel: React.FC<Props> = ({ gameState }) => {
       <div>
         <label className="text-sm mb-1 block">Shareable Link</label>
         <input type="text" readOnly value={url} className="border rounded p-2 w-full" />
+        <button
+          onClick={() => window.open(url, '_blank')}
+          className="mt-2 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors"
+        >
+          Open Scoreboard
+        </button>
       </div>
       <div className="border rounded p-4 bg-gray-100 dark:bg-gray-800">
         <Scoreboard gameState={gameState} width={width} height={height} />

--- a/src/components/ScoreboardPage.tsx
+++ b/src/components/ScoreboardPage.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { GameState } from '../types';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams, useNavigate } from 'react-router-dom';
 import { Scoreboard } from './Scoreboard';
+import { ControlPanelButton } from './ControlPanelButton';
 
 interface Props {
   gameState: GameState;
@@ -9,11 +10,13 @@ interface Props {
 
 export const ScoreboardPage: React.FC<Props> = ({ gameState }) => {
   const [params] = useSearchParams();
+  const navigate = useNavigate();
   const width = parseInt(params.get('width') || '800', 10);
   const height = parseInt(params.get('height') || '200', 10);
 
   return (
     <div className="w-screen h-screen flex items-center justify-center bg-transparent">
+      <ControlPanelButton onClick={() => navigate('/scoreboard/control')} />
       <Scoreboard gameState={gameState} width={width} height={height} />
     </div>
   );


### PR DESCRIPTION
## Summary
- add header buttons linking to scoreboard display and control panel
- provide quick link from control panel to open the scoreboard
- include control panel button on scoreboard page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899a7ccd920832dbc1d2b1cb3d01560