### PR TITLE
Add resolution presets and redesign scoreboard layout

### DIFF
--- a/src/components/Scoreboard.tsx
+++ b/src/components/Scoreboard.tsx
@@ -13,6 +13,15 @@ export const Scoreboard: React.FC<Props> = ({ gameState }) => {
   const [width, setWidth] = useState(800);
   const [height, setHeight] = useState(200);
 
+  const resolutions = [
+    { label: '800x200', width: 800, height: 200 },
+    { label: '1024x256', width: 1024, height: 256 },
+    { label: '1280x720', width: 1280, height: 720 },
+    { label: '1920x1080', width: 1920, height: 1080 },
+    { label: 'Custom', width: null, height: null },
+  ];
+  const [resolution, setResolution] = useState(resolutions[0].label);
+
   const [showScore, setShowScore] = useState(true);
   const [showFouls, setShowFouls] = useState(false);
   const [showHalf, setShowHalf] = useState(true);
@@ -21,6 +30,15 @@ export const Scoreboard: React.FC<Props> = ({ gameState }) => {
   const [layout, setLayout] = useState<'horizontal' | 'vertical'>('horizontal');
   const [bgColor, setBgColor] = useState('#000000');
   const [textColor, setTextColor] = useState('#ffffff');
+
+  const handleResolutionChange = (value: string) => {
+    setResolution(value);
+    const selected = resolutions.find(r => r.label === value);
+    if (selected && selected.width && selected.height) {
+      setWidth(selected.width);
+      setHeight(selected.height);
+    }
+  };
 
   const url = `${window.location.origin}/scoreboard/display?width=${width}&height=${height}` +
     `&showScore=${showScore ? 1 : 0}&showFouls=${showFouls ? 1 : 0}&showHalf=${showHalf ? 1 : 0}` +
@@ -32,23 +50,47 @@ export const Scoreboard: React.FC<Props> = ({ gameState }) => {
       <ControlPanelButton onClick={() => navigate('/dashboard')} />
       <div className="flex flex-wrap gap-4">
         <label className="flex flex-col">
-          <span className="text-sm mb-1">Width</span>
-          <input
-            type="number"
-            value={width}
-            onChange={e => setWidth(parseInt(e.target.value) || 0)}
-            className="border rounded p-1 w-24"
-          />
+          <span className="text-sm mb-1">Resolution</span>
+          <select
+            value={resolution}
+            onChange={e => handleResolutionChange(e.target.value)}
+            className="border rounded p-1"
+          >
+            {resolutions.map(r => (
+              <option key={r.label} value={r.label}>
+                {r.label}
+              </option>
+            ))}
+          </select>
         </label>
-        <label className="flex flex-col">
-          <span className="text-sm mb-1">Height</span>
-          <input
-            type="number"
-            value={height}
-            onChange={e => setHeight(parseInt(e.target.value) || 0)}
-            className="border rounded p-1 w-24"
-          />
-        </label>
+        {resolution === 'Custom' && (
+          <>
+            <label className="flex flex-col">
+              <span className="text-sm mb-1">Width</span>
+              <input
+                type="number"
+                value={width}
+                onChange={e => {
+                  setWidth(parseInt(e.target.value) || 0);
+                  setResolution('Custom');
+                }}
+                className="border rounded p-1 w-24"
+              />
+            </label>
+            <label className="flex flex-col">
+              <span className="text-sm mb-1">Height</span>
+              <input
+                type="number"
+                value={height}
+                onChange={e => {
+                  setHeight(parseInt(e.target.value) || 0);
+                  setResolution('Custom');
+                }}
+                className="border rounded p-1 w-24"
+              />
+            </label>
+          </>
+        )}
         <label className="flex items-center gap-2">
           <input type="checkbox" checked={showScore} onChange={e => setShowScore(e.target.checked)} />
           <span>Score</span>

--- a/src/components/ScoreboardDisplay.tsx
+++ b/src/components/ScoreboardDisplay.tsx
@@ -57,48 +57,54 @@ export const ScoreboardDisplay: React.FC<ScoreboardDisplayProps> = ({ gameState,
       ? 'flex flex-col items-center gap-2 px-4 py-2 rounded'
       : 'flex items-center justify-between px-4 py-2 rounded';
 
-  return (
-    <div className={containerClass} style={style}>
-      <div className="flex items-center gap-2">
-        {gameState.homeTeam.logo && (
-          <img
-            src={gameState.homeTeam.logo}
-            alt="Home logo"
-            className="h-8 w-8 object-contain"
-          />
-        )}
-        <span className="font-bold text-xl">
-          {gameState.homeTeam.name}
-          {showFouls && <span className="ml-2 text-sm">F:{gameState.homeTeam.fouls}</span>}
-        </span>
+  const renderTeam = (
+    team: GameState['homeTeam'],
+    reverse = false
+  ) => (
+    <div
+      className={`flex items-center gap-2 ${
+        reverse ? 'flex-row-reverse text-right' : ''
+      }`}
+    >
+      {team.logo && (
+        <img
+          src={team.logo}
+          alt="Team logo"
+          className="h-10 w-10 object-contain"
+        />
+      )}
+      <div className="flex flex-col">
+        <span className="font-bold text-xl truncate">{team.name}</span>
+        {showFouls && <span className="text-xs">Fouls: {team.fouls}</span>}
       </div>
+    </div>
+  );
+
+  const renderCenter = () => (
+    <div className="flex flex-col items-center mx-4">
       {showScore && (
-        <div className="text-3xl font-bold">
+        <div className="text-4xl font-extrabold leading-none">
           {gameState.homeTeam.score} - {gameState.awayTeam.score}
         </div>
       )}
-      <div className="flex items-center gap-2">
-        <span className="font-bold text-xl">
-          {gameState.awayTeam.name}
-          {showFouls && <span className="ml-2 text-sm">F:{gameState.awayTeam.fouls}</span>}
-        </span>
-        {gameState.awayTeam.logo && (
-          <img
-            src={gameState.awayTeam.logo}
-            alt="Away logo"
-            className="h-8 w-8 object-contain"
-          />
-        )}
-      </div>
-      {showTimer && (
-        <div className="flex flex-col items-end text-sm ml-4">
-          <span className="font-mono text-lg">
-            {String(minutes).padStart(2, '0')}:{String(seconds).padStart(2, '0')}
-          </span>
+      {(showTimer || showHalf) && (
+        <div className="flex items-center gap-2 text-sm mt-1">
+          {showTimer && (
+            <span className="font-mono text-lg">
+              {String(minutes).padStart(2, '0')}:{String(seconds).padStart(2, '0')}
+            </span>
+          )}
           {showHalf && <span>{period}</span>}
         </div>
       )}
-      {!showTimer && showHalf && <div className="text-sm ml-4">{period}</div>}
+    </div>
+  );
+
+  return (
+    <div className={containerClass} style={style}>
+      {renderTeam(gameState.homeTeam)}
+      {renderCenter()}
+      {renderTeam(gameState.awayTeam, true)}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Allow selecting common or custom scoreboard resolutions
- Revamp scoreboard display with team logos and central score/time block

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899b9b223c8832d9d82a73104ebcb91