### PR TITLE
Remove scoreboard display link from dashboard

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -12,7 +12,6 @@ import {
   Undo2,
   Redo2,
   Settings,
-  Monitor,
   SlidersHorizontal,
 } from 'lucide-react';
 import { useSettings } from '../hooks/useSettings';
@@ -181,13 +180,6 @@ export const Dashboard: React.FC<DashboardProps> = ({
           <div className="flex justify-between items-center py-4">
             <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Futsal Control Dashboard</h1>
             <div className="flex gap-3">
-              <button
-                onClick={() => window.open('/scoreboard/display', '_blank')}
-                className="inline-flex items-center gap-2 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors"
-              >
-                <Monitor className="w-4 h-4" />
-                Scoreboard Display
-              </button>
               <button
                 onClick={() => window.open('/scoreboard', '_blank')}
                 className="inline-flex items-center gap-2 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors"


### PR DESCRIPTION
## Summary
- remove Scoreboard Display button from dashboard so display page is opened only from the Scoreboard page

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899d47f36e4832db2ec063d938d46b9