### PR TITLE
feat: enhance scoreboard visuals

### DIFF
--- a/src/components/Scoreboard.tsx
+++ b/src/components/Scoreboard.tsx
@@ -31,7 +31,7 @@ export const Scoreboard: React.FC<Props> = ({ gameState, theme, toggleTheme }) =
   const [showTimer, setShowTimer] = useState(true);
   const [timerMode, setTimerMode] = useState<'elapsed' | 'remaining'>('elapsed');
   const [layout, setLayout] = useState<'horizontal' | 'vertical'>('horizontal');
-  const [bgColor, setBgColor] = useState('#000000');
+  const [bgColor, setBgColor] = useState('#1d4ed8');
   const [textColor, setTextColor] = useState('#ffffff');
 
   const handleResolutionChange = (value: string) => {

--- a/src/components/ScoreboardDisplay.tsx
+++ b/src/components/ScoreboardDisplay.tsx
@@ -28,7 +28,7 @@ export const ScoreboardDisplay: React.FC<ScoreboardDisplayProps> = ({ gameState,
     showTimer = true,
     timerMode = 'elapsed',
     layout = 'horizontal',
-    bgColor = '#000000',
+    bgColor = '#1d4ed8',
     textColor = '#ffffff',
   } = options || {};
 
@@ -59,7 +59,8 @@ export const ScoreboardDisplay: React.FC<ScoreboardDisplayProps> = ({ gameState,
 
   const renderTeam = (
     team: GameState['homeTeam'],
-    reverse = false
+    reverse = false,
+    variant: 'home' | 'away' = 'home'
   ) => (
     <div
       className={`flex items-center gap-2 ${
@@ -70,15 +71,21 @@ export const ScoreboardDisplay: React.FC<ScoreboardDisplayProps> = ({ gameState,
         <img
           src={team.logo}
           alt="Team logo"
-          className="h-12 w-12 object-cover rounded-full shadow-md"
+          className="h-[clamp(2.5rem,5vw,3.5rem)] w-[clamp(2.5rem,5vw,3.5rem)] object-cover rounded-full shadow-md"
         />
       )}
-      <div className="flex flex-col">
-        <span className="font-semibold text-2xl uppercase tracking-wide truncate">
+      <div
+        className={`flex flex-col px-3 py-1 rounded-lg text-white ${
+          variant === 'home'
+            ? 'bg-gradient-to-br from-blue-500 to-indigo-700'
+            : 'bg-gradient-to-br from-red-500 to-pink-700'
+        }`}
+      >
+        <span className="font-semibold uppercase tracking-wide truncate text-[clamp(1rem,2.5vw,2.5rem)]">
           {team.name}
         </span>
         {showFouls && (
-          <span className="text-sm opacity-80">Fouls: {team.fouls}</span>
+          <span className="text-[clamp(0.75rem,1.5vw,1rem)] opacity-90">Fouls: {team.fouls}</span>
         )}
       </div>
     </div>
@@ -87,12 +94,12 @@ export const ScoreboardDisplay: React.FC<ScoreboardDisplayProps> = ({ gameState,
   const renderCenter = () => (
     <div className="flex flex-col items-center mx-6">
       {showScore && (
-        <div className="font-mono text-6xl font-bold leading-none drop-shadow-md">
+        <div className="font-mono font-bold leading-none drop-shadow-md text-[clamp(2.5rem,8vw,6rem)]">
           {gameState.homeTeam.score} - {gameState.awayTeam.score}
         </div>
       )}
       {(showTimer || showHalf) && (
-        <div className="flex items-center gap-3 mt-2 text-lg">
+        <div className="flex items-center gap-3 mt-2 text-[clamp(1rem,2.5vw,1.5rem)]">
           {showTimer && (
             <span className="font-mono tracking-widest">
               {String(minutes).padStart(2, '0')}:{String(seconds).padStart(2, '0')}
@@ -106,9 +113,9 @@ export const ScoreboardDisplay: React.FC<ScoreboardDisplayProps> = ({ gameState,
 
   return (
     <div className={containerClass} style={style}>
-      {renderTeam(gameState.homeTeam)}
+      {renderTeam(gameState.homeTeam, false, 'home')}
       {renderCenter()}
-      {renderTeam(gameState.awayTeam, true)}
+      {renderTeam(gameState.awayTeam, true, 'away')}
     </div>
   );
 };

--- a/src/components/ScoreboardDisplayPage.tsx
+++ b/src/components/ScoreboardDisplayPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { GameState } from '../types';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { ScoreboardDisplay } from './ScoreboardDisplay';
@@ -14,6 +14,20 @@ export const ScoreboardDisplayPage: React.FC<Props> = ({ gameState }) => {
   const width = parseInt(params.get('width') || '800', 10);
   const height = parseInt(params.get('height') || '200', 10);
 
+  const [scale, setScale] = useState(1);
+
+  useEffect(() => {
+    const updateScale = () => {
+      const scaleX = window.innerWidth / width;
+      const scaleY = window.innerHeight / height;
+      setScale(Math.min(scaleX, scaleY));
+    };
+
+    updateScale();
+    window.addEventListener('resize', updateScale);
+    return () => window.removeEventListener('resize', updateScale);
+  }, [width, height]);
+
   const options = {
     showScore: params.get('showScore') !== '0',
     showFouls: params.get('showFouls') === '1',
@@ -21,14 +35,16 @@ export const ScoreboardDisplayPage: React.FC<Props> = ({ gameState }) => {
     showTimer: params.get('showTimer') !== '0',
     timerMode: (params.get('timerMode') as 'elapsed' | 'remaining') || 'elapsed',
     layout: (params.get('layout') as 'horizontal' | 'vertical') || 'horizontal',
-    bgColor: params.get('bgColor') ? decodeURIComponent(params.get('bgColor') as string) : '#000000',
+    bgColor: params.get('bgColor') ? decodeURIComponent(params.get('bgColor') as string) : '#1d4ed8',
     textColor: params.get('textColor') ? decodeURIComponent(params.get('textColor') as string) : '#ffffff',
   } as const;
 
   return (
     <div className="w-screen h-screen flex items-center justify-center bg-transparent">
       <ControlPanelButton onClick={() => navigate('/scoreboard')} />
-      <ScoreboardDisplay gameState={gameState} width={width} height={height} options={options} />
+      <div style={{ transform: `scale(${scale})`, transformOrigin: 'center' }}>
+        <ScoreboardDisplay gameState={gameState} width={width} height={height} options={options} />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- make scoreboard display responsive to screen resolution
- add colorful gradients and responsive typography for team names
- set vibrant default background for scoreboard

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c59407e5c832d806c5b77a2e1a927