### PR TITLE
feat: make scoreboard responsive

### DIFF
--- a/src/components/ScoreboardDisplay.tsx
+++ b/src/components/ScoreboardDisplay.tsx
@@ -46,16 +46,27 @@ export const ScoreboardDisplay: React.FC<ScoreboardDisplayProps> = ({ gameState,
   }
 
   const style: React.CSSProperties = {
-    width: width ? `${width}px` : undefined,
+    width: width ? `${width}px` : '100%',
     height: height ? `${height}px` : undefined,
     backgroundColor: bgColor,
     color: textColor,
   };
 
+  // derive a few sizing values from the provided height.  This keeps
+  // the scoreboard looking consistent for any resolution because the
+  // font and logo sizes scale with the physical size of the board
+  // rather than with the browser viewport.
+  const baseHeight = height || 200;
+  const logoSize = baseHeight * 0.4; // 40% of the board height
+  const teamFontSize = baseHeight * 0.2;
+  const foulsFontSize = baseHeight * 0.12;
+  const scoreFontSize = baseHeight * 0.5;
+  const infoFontSize = baseHeight * 0.2;
+
   const containerClass =
     layout === 'vertical'
       ? 'flex flex-col items-center gap-6 px-8 py-6 rounded-2xl shadow-2xl backdrop-blur-sm'
-      : 'flex items-center justify-between gap-8 px-8 py-6 rounded-2xl shadow-2xl backdrop-blur-sm';
+      : 'grid grid-cols-[1fr_auto_1fr] items-center px-8 py-6 rounded-2xl shadow-2xl backdrop-blur-sm';
 
   const renderTeam = (
     team: GameState['homeTeam'],
@@ -63,15 +74,15 @@ export const ScoreboardDisplay: React.FC<ScoreboardDisplayProps> = ({ gameState,
     variant: 'home' | 'away' = 'home'
   ) => (
     <div
-      className={`flex items-center gap-2 ${
-        reverse ? 'flex-row-reverse text-right' : ''
-      }`}
+      className={`flex items-center gap-2 ${reverse ? 'flex-row-reverse text-right' : ''}`}
+      style={{ gap: baseHeight * 0.05 }}
     >
       {team.logo && (
         <img
           src={team.logo}
           alt="Team logo"
-          className="h-[clamp(2.5rem,5vw,3.5rem)] w-[clamp(2.5rem,5vw,3.5rem)] object-cover rounded-full shadow-md"
+          style={{ width: logoSize, height: logoSize }}
+          className="object-cover rounded-full shadow-md flex-shrink-0"
         />
       )}
       <div
@@ -80,26 +91,35 @@ export const ScoreboardDisplay: React.FC<ScoreboardDisplayProps> = ({ gameState,
             ? 'bg-gradient-to-br from-blue-500 to-indigo-700'
             : 'bg-gradient-to-br from-red-500 to-pink-700'
         }`}
+        style={{ fontSize: teamFontSize }}
       >
-        <span className="font-semibold uppercase tracking-wide truncate text-[clamp(1rem,2.5vw,2.5rem)]">
+        <span className="font-semibold uppercase tracking-wide truncate">
           {team.name}
         </span>
         {showFouls && (
-          <span className="text-[clamp(0.75rem,1.5vw,1rem)] opacity-90">Fouls: {team.fouls}</span>
+          <span style={{ fontSize: foulsFontSize }} className="opacity-90">
+            Fouls: {team.fouls}
+          </span>
         )}
       </div>
     </div>
   );
 
   const renderCenter = () => (
-    <div className="flex flex-col items-center mx-6">
+    <div
+      className="flex flex-col items-center flex-shrink-0"
+      style={{ gap: baseHeight * 0.1 }}
+    >
       {showScore && (
-        <div className="font-mono font-bold leading-none drop-shadow-md text-[clamp(2.5rem,8vw,6rem)]">
+        <div
+          className="font-mono font-bold leading-none drop-shadow-md"
+          style={{ fontSize: scoreFontSize }}
+        >
           {gameState.homeTeam.score} - {gameState.awayTeam.score}
         </div>
       )}
       {(showTimer || showHalf) && (
-        <div className="flex items-center gap-3 mt-2 text-[clamp(1rem,2.5vw,1.5rem)]">
+        <div className="flex items-center gap-3" style={{ fontSize: infoFontSize }}>
           {showTimer && (
             <span className="font-mono tracking-widest">
               {String(minutes).padStart(2, '0')}:{String(seconds).padStart(2, '0')}
@@ -113,9 +133,9 @@ export const ScoreboardDisplay: React.FC<ScoreboardDisplayProps> = ({ gameState,
 
   return (
     <div className={containerClass} style={style}>
-      {renderTeam(gameState.homeTeam, false, 'home')}
-      {renderCenter()}
-      {renderTeam(gameState.awayTeam, true, 'away')}
+      <div className="justify-self-start min-w-0">{renderTeam(gameState.homeTeam, false, 'home')}</div>
+      <div className="justify-self-center">{renderCenter()}</div>
+      <div className="justify-self-end min-w-0">{renderTeam(gameState.awayTeam, true, 'away')}</div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- derive fonts and logo sizes from scoreboard height to scale with resolution
- grid layout splits board into home, center, and away sections to prevent overlap
- default width spans container so layout respects boundaries

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c6836d07c832da97b3e6ac57a55ec