### PR TITLE
Redesign scoreboard layout with smaller fonts

### DIFF
--- a/src/components/ScoreboardDisplay.tsx
+++ b/src/components/ScoreboardDisplay.tsx
@@ -20,7 +20,12 @@ interface ScoreboardDisplayProps {
   options?: ScoreboardDisplayOptions;
 }
 
-export const ScoreboardDisplay: React.FC<ScoreboardDisplayProps> = ({ gameState, width, height, options }) => {
+export const ScoreboardDisplay: React.FC<ScoreboardDisplayProps> = ({
+  gameState,
+  width,
+  height,
+  options,
+}) => {
   const {
     showScore = true,
     showFouls = false,
@@ -32,7 +37,11 @@ export const ScoreboardDisplay: React.FC<ScoreboardDisplayProps> = ({ gameState,
     textColor = '#ffffff',
   } = options || {};
 
-  const period = getHalfName(gameState.half, gameState.gamePreset, gameState.matchPhase);
+  const period = getHalfName(
+    gameState.half,
+    gameState.gamePreset,
+    gameState.matchPhase,
+  );
 
   let minutes = gameState.time.minutes;
   let seconds = gameState.time.seconds;
@@ -52,78 +61,37 @@ export const ScoreboardDisplay: React.FC<ScoreboardDisplayProps> = ({ gameState,
     color: textColor,
   };
 
-  // derive a few sizing values from the provided height.  This keeps
-  // the scoreboard looking consistent for any resolution because the
-  // font and logo sizes scale with the physical size of the board
-  // rather than with the browser viewport.
-  const baseHeight = height || 200;
-  const logoSize = baseHeight * 0.4; // 40% of the board height
-  const teamFontSize = baseHeight * 0.2;
-  const foulsFontSize = baseHeight * 0.12;
-  const scoreFontSize = baseHeight * 0.5;
-  const infoFontSize = baseHeight * 0.2;
-
-  const containerClass =
-    layout === 'vertical'
-      ? 'flex flex-col items-center gap-6 px-8 py-6 rounded-2xl shadow-2xl backdrop-blur-sm'
-      : 'grid grid-cols-[1fr_auto_1fr] items-center gap-4 px-8 py-6 rounded-2xl shadow-2xl backdrop-blur-sm';
-
   const renderTeam = (
     team: GameState['homeTeam'],
-    reverse = false,
-    variant: 'home' | 'away' = 'home'
   ) => (
-    <div
-      className={`flex items-center gap-2 w-full min-w-0 overflow-hidden ${
-        reverse ? 'flex-row-reverse text-right' : ''
-      }`}
-      style={{ gap: baseHeight * 0.05 }}
-    >
+    <div className="flex flex-col items-center min-w-0">
       {team.logo && (
         <img
           src={team.logo}
           alt="Team logo"
-          style={{ width: logoSize, height: logoSize }}
-          className="object-cover rounded-full shadow-md flex-shrink-0"
+          className="w-12 h-12 object-cover rounded-full mb-2"
         />
       )}
-      <div
-        className={`flex flex-col px-3 py-1 rounded-lg text-white flex-1 min-w-0 ${
-          variant === 'home'
-            ? 'bg-gradient-to-br from-blue-500 to-indigo-700'
-            : 'bg-gradient-to-br from-red-500 to-pink-700'
-        }`}
-        style={{ fontSize: teamFontSize }}
-      >
-        <span className="font-semibold uppercase tracking-wide truncate">
-          {team.name}
-        </span>
-        {showFouls && (
-          <span style={{ fontSize: foulsFontSize }} className="opacity-90">
-            Fouls: {team.fouls}
-          </span>
-        )}
-      </div>
+      <span className="text-lg font-semibold truncate">
+        {team.name}
+      </span>
+      {showFouls && (
+        <span className="text-sm opacity-80">Fouls: {team.fouls}</span>
+      )}
     </div>
   );
 
   const renderCenter = () => (
-    <div
-      className="flex flex-col items-center flex-shrink-0"
-      style={{ gap: baseHeight * 0.1 }}
-    >
+    <div className="flex flex-col items-center">
       {showScore && (
-        <div
-          className="font-mono font-bold leading-none drop-shadow-md"
-          style={{ fontSize: scoreFontSize }}
-        >
+        <div className="text-4xl font-bold font-mono mb-2">
           {gameState.homeTeam.score} - {gameState.awayTeam.score}
         </div>
       )}
       {(showTimer || showHalf) && (
-        <div className="flex items-center gap-3" style={{ fontSize: infoFontSize }}>
+        <div className="text-sm flex items-center space-x-2">
           {showTimer && (
-            <span className="font-mono tracking-widest">
+            <span className="font-mono">
               {String(minutes).padStart(2, '0')}:{String(seconds).padStart(2, '0')}
             </span>
           )}
@@ -133,11 +101,28 @@ export const ScoreboardDisplay: React.FC<ScoreboardDisplayProps> = ({ gameState,
     </div>
   );
 
+  const horizontalLayout = (
+    <div className="grid grid-cols-3 items-center gap-4">
+      {renderTeam(gameState.homeTeam)}
+      {renderCenter()}
+      {renderTeam(gameState.awayTeam)}
+    </div>
+  );
+
+  const verticalLayout = (
+    <div className="flex flex-col items-center space-y-4">
+      {renderTeam(gameState.homeTeam)}
+      {renderCenter()}
+      {renderTeam(gameState.awayTeam)}
+    </div>
+  );
+
   return (
-    <div className={containerClass} style={style}>
-      <div className="min-w-0 justify-self-start">{renderTeam(gameState.homeTeam, false, 'home')}</div>
-      <div className="justify-self-center">{renderCenter()}</div>
-      <div className="min-w-0 justify-self-end">{renderTeam(gameState.awayTeam, true, 'away')}</div>
+    <div
+      className="p-4 rounded-xl shadow-xl"
+      style={style}
+    >
+      {layout === 'vertical' ? verticalLayout : horizontalLayout}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- replace scoreboard component with new grid/flex layout and reduced font sizes
- revert global font-size changes to keep site-wide typography intact

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_689cc161513c832db1c679d797d76d5e