### PR TITLE
Refactor scoreboard to horizontal grid layout

### DIFF
--- a/src/components/ScoreboardDisplay.tsx
+++ b/src/components/ScoreboardDisplay.tsx
@@ -1,14 +1,10 @@
 import React from 'react';
 import { GameState } from '../types';
-import { getHalfName } from '../utils/gamePresets';
 
 interface ScoreboardDisplayOptions {
   showScore?: boolean;
-  showFouls?: boolean;
-  showHalf?: boolean;
   showTimer?: boolean;
   timerMode?: 'elapsed' | 'remaining';
-  layout?: 'horizontal' | 'vertical';
   bgColor?: string;
   textColor?: string;
 }
@@ -20,6 +16,26 @@ interface ScoreboardDisplayProps {
   options?: ScoreboardDisplayOptions;
 }
 
+const TeamLogoA: React.FC<{ size: string }> = ({ size }) => (
+  <svg viewBox="0 0 100 100" width={size} height={size} className="fill-current">
+    <polygon points="50,10 90,90 10,90" />
+  </svg>
+);
+
+const TeamLogoB: React.FC<{ size: string }> = ({ size }) => (
+  <svg viewBox="0 0 100 100" width={size} height={size} className="fill-current">
+    <polygon points="50,10 90,90 10,90" />
+    <circle cx="50" cy="60" r="20" fill="none" stroke="currentColor" strokeWidth="10" />
+  </svg>
+);
+
+const CompetitionLogo: React.FC<{ width: string; height: string }> = ({ width, height }) => (
+  <svg viewBox="0 0 100 60" width={width} height={height} className="stroke-current fill-none">
+    <rect x="5" y="5" width="90" height="50" rx="15" ry="15" strokeWidth="10" />
+    <ellipse cx="50" cy="30" rx="25" ry="12" strokeWidth="10" />
+  </svg>
+);
+
 export const ScoreboardDisplay: React.FC<ScoreboardDisplayProps> = ({
   gameState,
   width,
@@ -28,20 +44,11 @@ export const ScoreboardDisplay: React.FC<ScoreboardDisplayProps> = ({
 }) => {
   const {
     showScore = true,
-    showFouls = false,
-    showHalf = true,
     showTimer = true,
     timerMode = 'elapsed',
-    layout = 'horizontal',
     bgColor = '#1d4ed8',
     textColor = '#ffffff',
   } = options || {};
-
-  const period = getHalfName(
-    gameState.half,
-    gameState.gamePreset,
-    gameState.matchPhase,
-  );
 
   let minutes = gameState.time.minutes;
   let seconds = gameState.time.seconds;
@@ -61,82 +68,65 @@ export const ScoreboardDisplay: React.FC<ScoreboardDisplayProps> = ({
     color: textColor,
   };
 
-  const baseWidth = 800;
-  const baseHeight = 200;
-  const scale = Math.min(
-    width ? width / baseWidth : 1,
-    height ? height / baseHeight : 1,
-  );
-  const logoSize = `${3 * scale}rem`;
-  const teamFontSize = `${1.125 * scale}rem`;
-  const infoFontSize = `${0.875 * scale}rem`;
-  const scoreFontSize = `${2.25 * scale}rem`;
-
-  const renderTeam = (
-    team: GameState['homeTeam'],
-  ) => (
-    <div className="flex flex-col items-center min-w-0">
-      {team.logo && (
-        <img
-          src={team.logo}
-          alt="Team logo"
-          style={{ width: logoSize, height: logoSize }}
-          className="object-cover rounded-full mb-2"
-        />
-      )}
-      <span className="font-semibold truncate" style={{ fontSize: teamFontSize }}>
-        {team.name}
-      </span>
-      {showFouls && (
-        <span className="opacity-80" style={{ fontSize: infoFontSize }}>
-          Fouls: {team.fouls}
-        </span>
-      )}
-    </div>
-  );
-
-  const renderCenter = () => (
-    <div className="flex flex-col items-center">
-      {showScore && (
-        <div className="font-bold font-mono mb-2" style={{ fontSize: scoreFontSize }}>
-          {gameState.homeTeam.score} - {gameState.awayTeam.score}
-        </div>
-      )}
-      {(showTimer || showHalf) && (
-        <div className="flex items-center space-x-2" style={{ fontSize: infoFontSize }}>
-          {showTimer && (
-            <span className="font-mono">
-              {String(minutes).padStart(2, '0')}:{String(seconds).padStart(2, '0')}
-            </span>
-          )}
-          {showHalf && <span className="uppercase tracking-wide">{period}</span>}
-        </div>
-      )}
-    </div>
-  );
-
-  const horizontalLayout = (
-    <div className="grid grid-cols-3 items-center gap-4">
-      {renderTeam(gameState.homeTeam)}
-      {renderCenter()}
-      {renderTeam(gameState.awayTeam)}
-    </div>
-  );
-
-  const verticalLayout = (
-    <div className="flex flex-col items-center space-y-4">
-      {renderTeam(gameState.homeTeam)}
-      {renderCenter()}
-      {renderTeam(gameState.awayTeam)}
-    </div>
-  );
+  const logoSize = 'clamp(2rem, 8vw, 6rem)';
+  const compWidth = 'clamp(4rem, 12vw, 8rem)';
+  const compHeight = 'clamp(2rem, 6vw, 4rem)';
+  const timerFont = 'clamp(1.5rem, 6vw, 4rem)';
+  const scoreFont = 'clamp(2rem, 8vw, 5rem)';
+  const labelFont = 'clamp(0.5rem, 2vw, 1.25rem)';
+  const teamFont = 'clamp(1rem, 4vw, 2.5rem)';
 
   return (
-    <div
-      className="p-4 rounded-xl shadow-xl"
-      style={style}
-    >
-      {layout === 'vertical' ? verticalLayout : horizontalLayout}
+    <div className="grid grid-rows-3 w-full h-full p-2 gap-y-2" style={style}>
+      <div className="grid grid-cols-3 items-center">
+        <div className="justify-self-start">
+          <TeamLogoA size={logoSize} />
+        </div>
+        <div className="justify-self-center font-mono font-bold" style={{ fontSize: timerFont }}>
+          {showTimer ? (
+            <>{String(minutes).padStart(2, '0')}:{String(seconds).padStart(2, '0')}</>
+          ) : null}
+        </div>
+        <div className="justify-self-end">
+          <TeamLogoB size={logoSize} />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 items-center">
+        <div className="justify-self-start">
+          {showScore && (
+            <div className="flex flex-col items-start">
+              <span className="font-mono font-bold leading-none" style={{ fontSize: scoreFont }}>
+                {String(gameState.homeTeam.score).padStart(2, '0')}
+              </span>
+              <span style={{ fontSize: labelFont }}>Score</span>
+            </div>
+          )}
+        </div>
+        <div className="justify-self-center">
+          <CompetitionLogo width={compWidth} height={compHeight} />
+        </div>
+        <div className="justify-self-end">
+          {showScore && (
+            <div className="flex flex-col items-end">
+              <span className="font-mono font-bold leading-none" style={{ fontSize: scoreFont }}>
+                {String(gameState.awayTeam.score).padStart(2, '0')}
+              </span>
+              <span style={{ fontSize: labelFont }}>Score</span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 items-center">
+        <span className="justify-self-start truncate font-semibold" style={{ fontSize: teamFont }}>
+          {gameState.homeTeam.name}
+        </span>
+        <span className="justify-self-end truncate font-semibold text-right" style={{ fontSize: teamFont }}>
+          {gameState.awayTeam.name}
+        </span>
+      </div>
     </div>
   );
 };
+


### PR DESCRIPTION
## Summary
- redesign scoreboard display with 3-row CSS grid to match horizontal wireframe
- add inline SVG placeholders for team and competition logos

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d7f79709c832d8552b28c6f5a8eda