### PR TITLE
Fix scoreboard timer sync when pausing game

### DIFF
--- a/src/hooks/useGameState.test.ts
+++ b/src/hooks/useGameState.test.ts
@@ -39,6 +39,31 @@ describe('useGameState message handling', () => {
 
     unmount();
   });
+
+  it('updates state on STATE_UPDATE messages', () => {
+    const { result, unmount } = renderHook(() => useGameState(), { legacyRoot: true });
+
+    const updatedState = {
+      ...result.current.gameState,
+      isRunning: true,
+      time: { minutes: 10, seconds: 15 },
+    };
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: { type: 'STATE_UPDATE', state: updatedState },
+          origin: window.location.origin,
+        }),
+      );
+    });
+
+    expect(result.current.gameState.isRunning).toBe(true);
+    expect(result.current.gameState.time.minutes).toBe(10);
+    expect(result.current.gameState.time.seconds).toBe(15);
+
+    unmount();
+  });
 });
 
 describe('useGameState history', () => {

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -142,6 +142,7 @@ export const useGameState = () => {
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const keyboardListenerRef = useRef<((event: KeyboardEvent) => void) | null>(null);
   const skipStorageRef = useRef(false);
+  const skipBroadcastRef = useRef(false);
   const channelRef = useRef<BroadcastChannel | null>(null);
   const maxHalfRef = useRef(gameState.half);
 
@@ -894,6 +895,15 @@ export const useGameState = () => {
           }
           break;
         }
+        case 'STATE_UPDATE': {
+          const { state } = data as { state?: GameState };
+          if (state) {
+            skipStorageRef.current = true;
+            skipBroadcastRef.current = true;
+            _setGameState(() => state as GameState);
+          }
+          break;
+        }
         default:
           break;
       }
@@ -922,6 +932,10 @@ export const useGameState = () => {
   }, [handleRemoteMessage]);
 
   useEffect(() => {
+    if (skipBroadcastRef.current) {
+      skipBroadcastRef.current = false;
+      return;
+    }
     channelRef.current?.postMessage({ type: 'STATE_UPDATE', state: gameState });
   }, [gameState]);
 


### PR DESCRIPTION
## Summary
- handle `STATE_UPDATE` messages and skip broadcasting to avoid loops
- test broadcast handling for remote state updates

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '/workspace/futsal/node_modules/@eslint/js/index.js')*


------
https://chatgpt.com/codex/tasks/task_e_689dac0a3b3c832db53d9823e8173458