### PR TITLE
feat: show paused state on scoreboard

### DIFF
--- a/src/components/ScoreboardDisplay.test.tsx
+++ b/src/components/ScoreboardDisplay.test.tsx
@@ -1,0 +1,57 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { ScoreboardDisplay } from './ScoreboardDisplay';
+
+const baseTeam = {
+  name: 'Team',
+  score: 0,
+  fouls: 0,
+  stats: {
+    shotsOffTarget: 0,
+    shotsOnTarget: 0,
+    corners: 0,
+    yellowCards: 0,
+    redCards: 0,
+    possession: 50,
+  },
+  players: [],
+};
+
+const baseGameState = {
+  homeTeam: { ...baseTeam, name: 'Home' },
+  awayTeam: { ...baseTeam, name: 'Away' },
+  time: { minutes: 12, seconds: 34 },
+  half: 1,
+  isRunning: false,
+  ballPossession: 'home' as const,
+  possessionStartTime: 0,
+  totalPossessionTime: { home: 0, away: 0 },
+  gamePreset: {
+    type: 'futsal' as const,
+    format: 'regular' as const,
+    name: 'Preset',
+    description: '',
+    halfDuration: 20,
+    totalHalves: 2,
+    hasExtraTime: false,
+    extraTimeDuration: 5,
+    hasPenalties: false,
+    allowsDraws: true,
+  },
+  matchPhase: 'regular' as const,
+};
+
+describe('ScoreboardDisplay', () => {
+  it('shows paused indicator when game is not running', () => {
+    const { getByText } = render(<ScoreboardDisplay gameState={baseGameState} />);
+    expect(getByText(/paused/i)).toBeInTheDocument();
+  });
+
+  it('does not show paused indicator when game is running', () => {
+    const runningState = { ...baseGameState, isRunning: true };
+    const { queryByText } = render(<ScoreboardDisplay gameState={runningState} />);
+    expect(queryByText(/paused/i)).toBeNull();
+  });
+});
+

--- a/src/components/ScoreboardDisplay.tsx
+++ b/src/components/ScoreboardDisplay.tsx
@@ -74,6 +74,7 @@ export const ScoreboardDisplay: React.FC<ScoreboardDisplayProps> = ({
   const timerFont = `${baseHeight * 0.3}px`;
   const scoreFont = `${baseHeight * 0.35}px`;
   const teamFont = `${baseHeight * 0.25}px`;
+  const pausedFont = `${baseHeight * 0.15}px`;
 
   return (
     <div className="grid grid-rows-3 w-full h-full p-2 gap-y-2" style={style}>
@@ -81,10 +82,17 @@ export const ScoreboardDisplay: React.FC<ScoreboardDisplayProps> = ({
         <div className="justify-self-start">
           <TeamLogo src={gameState.homeTeam.logo} size={logoSize} />
         </div>
-        <div className="justify-self-center font-mono font-bold" style={{ fontSize: timerFont }}>
-          {showTimer ? (
-            <>{String(minutes).padStart(2, '0')}:{String(seconds).padStart(2, '0')}</>
-          ) : null}
+        <div className="justify-self-center font-mono font-bold flex flex-col items-center">
+          {showTimer && (
+            <span style={{ fontSize: timerFont }}>
+              {String(minutes).padStart(2, '0')}:{String(seconds).padStart(2, '0')}
+            </span>
+          )}
+          {!gameState.isRunning && (
+            <span className="uppercase" style={{ fontSize: pausedFont }}>
+              Paused
+            </span>
+          )}
         </div>
         <div className="justify-self-end">
           <TeamLogo src={gameState.awayTeam.logo} size={logoSize} />


### PR DESCRIPTION
## Summary
- show "Paused" label on scoreboard when game is not running
- add tests for paused indicator

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689db7adc508832db878a1c7edbb57a7