### PR TITLE
feat: individual team and timer colors for scoreboard

### DIFF
--- a/src/components/Scoreboard.tsx
+++ b/src/components/Scoreboard.tsx
@@ -32,7 +32,9 @@ export const Scoreboard: React.FC<Props> = ({ gameState, theme, toggleTheme }) =
   const [timerMode, setTimerMode] = useState<'elapsed' | 'remaining'>('elapsed');
   const [layout, setLayout] = useState<'horizontal' | 'vertical'>('horizontal');
   const [bgColor, setBgColor] = useState('#1d4ed8');
-  const [textColor, setTextColor] = useState('#ffffff');
+  const [teamAColor, setTeamAColor] = useState('#3b82f6');
+  const [teamBColor, setTeamBColor] = useState('#ef4444');
+  const [timerColor, setTimerColor] = useState('#ffffff');
 
   const handleResolutionChange = (value: string) => {
     setResolution(value);
@@ -46,7 +48,10 @@ export const Scoreboard: React.FC<Props> = ({ gameState, theme, toggleTheme }) =
   const url = `${window.location.origin}/scoreboard/display?width=${width}&height=${height}` +
     `&showScore=${showScore ? 1 : 0}&showFouls=${showFouls ? 1 : 0}&showHalf=${showHalf ? 1 : 0}` +
     `&showTimer=${showTimer ? 1 : 0}&timerMode=${timerMode}&layout=${layout}` +
-    `&bgColor=${encodeURIComponent(bgColor)}&textColor=${encodeURIComponent(textColor)}`;
+    `&bgColor=${encodeURIComponent(bgColor)}` +
+    `&teamAColor=${encodeURIComponent(teamAColor)}` +
+    `&teamBColor=${encodeURIComponent(teamBColor)}` +
+    `&timerColor=${encodeURIComponent(timerColor)}`;
 
   return (
     <div className="min-h-screen p-4 space-y-4 relative bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
@@ -134,20 +139,38 @@ export const Scoreboard: React.FC<Props> = ({ gameState, theme, toggleTheme }) =
           </select>
         </div>
         <label className="flex items-center gap-2">
+          <span>Team A</span>
+          <input
+            type="color"
+            value={teamAColor}
+            onChange={e => setTeamAColor(e.target.value)}
+            className="border border-gray-300 dark:border-gray-600 rounded bg-transparent"
+          />
+        </label>
+        <label className="flex items-center gap-2">
+          <span>Team B</span>
+          <input
+            type="color"
+            value={teamBColor}
+            onChange={e => setTeamBColor(e.target.value)}
+            className="border border-gray-300 dark:border-gray-600 rounded bg-transparent"
+          />
+        </label>
+        <label className="flex items-center gap-2">
+          <span>Timer</span>
+          <input
+            type="color"
+            value={timerColor}
+            onChange={e => setTimerColor(e.target.value)}
+            className="border border-gray-300 dark:border-gray-600 rounded bg-transparent"
+          />
+        </label>
+        <label className="flex items-center gap-2">
           <span>BG</span>
           <input
             type="color"
             value={bgColor}
             onChange={e => setBgColor(e.target.value)}
-            className="border border-gray-300 dark:border-gray-600 rounded bg-transparent"
-          />
-        </label>
-        <label className="flex items-center gap-2">
-          <span>Text</span>
-          <input
-            type="color"
-            value={textColor}
-            onChange={e => setTextColor(e.target.value)}
             className="border border-gray-300 dark:border-gray-600 rounded bg-transparent"
           />
         </label>
@@ -180,7 +203,9 @@ export const Scoreboard: React.FC<Props> = ({ gameState, theme, toggleTheme }) =
             timerMode,
             layout,
             bgColor,
-            textColor,
+            teamAColor,
+            teamBColor,
+            timerColor,
           }}
         />
       </div>

--- a/src/components/ScoreboardDisplay.tsx
+++ b/src/components/ScoreboardDisplay.tsx
@@ -9,7 +9,9 @@ interface ScoreboardDisplayOptions {
   timerMode?: 'elapsed' | 'remaining';
   layout?: 'horizontal' | 'vertical';
   bgColor?: string;
-  textColor?: string;
+  teamAColor?: string;
+  teamBColor?: string;
+  timerColor?: string;
 }
 
 interface ScoreboardDisplayProps {
@@ -78,7 +80,9 @@ export const ScoreboardDisplay: React.FC<ScoreboardDisplayProps> = ({
     timerMode = 'elapsed',
     layout = 'horizontal',
     bgColor = '#1d4ed8',
-    textColor = '#ffffff',
+    teamAColor = '#3b82f6',
+    teamBColor = '#ef4444',
+    timerColor = '#ffffff',
   } = options || {};
 
   let minutes = gameState.time.minutes;
@@ -92,12 +96,14 @@ export const ScoreboardDisplay: React.FC<ScoreboardDisplayProps> = ({
     seconds = remaining % 60;
   }
 
-  const style: React.CSSProperties = {
+  const style = {
     width: width ? `${width}px` : undefined,
     height: height ? `${height}px` : undefined,
     backgroundColor: bgColor,
-    color: textColor,
-  };
+    '--team-a-color': teamAColor,
+    '--team-b-color': teamBColor,
+    '--timer-color': timerColor,
+  } as React.CSSProperties;
 
   // Account for padding (p-2 => 8px each side) and vertical gaps (gap-y-2 => 8px each)
   // to ensure the computed content sizes fit within the provided height.
@@ -141,23 +147,23 @@ export const ScoreboardDisplay: React.FC<ScoreboardDisplayProps> = ({
   const horizontalLayout = (
     <div className="grid grid-rows-[auto_1fr_auto] w-full h-full p-2 gap-y-2" style={style}>
       <div className="grid grid-cols-3 items-center">
-        <div className="justify-self-start">
+        <div className="justify-self-start" style={{ color: 'var(--team-a-color)' }}>
           <TeamLogo src={gameState.homeTeam.logo} size={logoSize} />
         </div>
         <div className="justify-self-center font-mono font-bold flex flex-col items-center">
-          {showHalf && <span style={{ fontSize: halfFont }}>{halfText}</span>}
+          {showHalf && <span style={{ fontSize: halfFont, color: 'var(--timer-color)' }}>{halfText}</span>}
           {showTimer && (
-            <span style={{ fontSize: timerFont }}>
+            <span style={{ fontSize: timerFont, color: 'var(--timer-color)' }}>
               {String(minutes).padStart(2, '0')}:{String(seconds).padStart(2, '0')}
             </span>
           )}
           {!gameState.isRunning && (
-            <span className="uppercase" style={{ fontSize: pausedFont }}>
+            <span className="uppercase" style={{ fontSize: pausedFont, color: 'var(--timer-color)' }}>
               Paused
             </span>
           )}
         </div>
-        <div className="justify-self-end">
+        <div className="justify-self-end" style={{ color: 'var(--team-b-color)' }}>
           <TeamLogo src={gameState.awayTeam.logo} size={logoSize} />
         </div>
       </div>
@@ -166,29 +172,29 @@ export const ScoreboardDisplay: React.FC<ScoreboardDisplayProps> = ({
         <div className="justify-self-start">
           <div className="flex flex-col items-start">
             {showScore && (
-              <span className="font-mono font-bold leading-none" style={{ fontSize: scoreFont }}>
+              <span className="font-mono font-bold leading-none" style={{ fontSize: scoreFont, color: 'var(--team-a-color)' }}>
                 {String(gameState.homeTeam.score).padStart(2, '0')}
               </span>
             )}
             {showFouls && (
-              <span className="font-mono leading-none" style={{ fontSize: foulsFont }}>
+              <span className="font-mono leading-none" style={{ fontSize: foulsFont, color: 'var(--team-a-color)' }}>
                 F:{gameState.homeTeam.fouls}
               </span>
             )}
           </div>
         </div>
-        <div className="justify-self-center">
+        <div className="justify-self-center" style={{ color: 'var(--timer-color)' }}>
           <TournamentLogo src={gameState.tournamentLogo} width={compWidth} height={compHeight} />
         </div>
         <div className="justify-self-end">
           <div className="flex flex-col items-end">
             {showScore && (
-              <span className="font-mono font-bold leading-none" style={{ fontSize: scoreFont }}>
+              <span className="font-mono font-bold leading-none" style={{ fontSize: scoreFont, color: 'var(--team-b-color)' }}>
                 {String(gameState.awayTeam.score).padStart(2, '0')}
               </span>
             )}
             {showFouls && (
-              <span className="font-mono leading-none" style={{ fontSize: foulsFont }}>
+              <span className="font-mono leading-none" style={{ fontSize: foulsFont, color: 'var(--team-b-color)' }}>
                 F:{gameState.awayTeam.fouls}
               </span>
             )}
@@ -200,14 +206,14 @@ export const ScoreboardDisplay: React.FC<ScoreboardDisplayProps> = ({
         <span
           ref={homeNameRef}
           className="justify-self-start truncate font-semibold leading-none"
-          style={{ fontSize: teamFont }}
+          style={{ fontSize: teamFont, color: 'var(--team-a-color)' }}
         >
           {gameState.homeTeam.name}
         </span>
         <span
           ref={awayNameRef}
           className="justify-self-end truncate font-semibold text-right leading-none"
-          style={{ fontSize: teamFont }}
+          style={{ fontSize: teamFont, color: 'var(--team-b-color)' }}
         >
           {gameState.awayTeam.name}
         </span>
@@ -218,14 +224,14 @@ export const ScoreboardDisplay: React.FC<ScoreboardDisplayProps> = ({
   const verticalLayout = (
     <div className="flex flex-col w-full h-full p-2 gap-y-2" style={style}>
       <div className="flex flex-col items-center font-mono font-bold">
-        {showHalf && <span style={{ fontSize: halfFont }}>{halfText}</span>}
+        {showHalf && <span style={{ fontSize: halfFont, color: 'var(--timer-color)' }}>{halfText}</span>}
         {showTimer && (
-          <span style={{ fontSize: timerFont }}>
+          <span style={{ fontSize: timerFont, color: 'var(--timer-color)' }}>
             {String(minutes).padStart(2, '0')}:{String(seconds).padStart(2, '0')}
           </span>
         )}
         {!gameState.isRunning && (
-          <span className="uppercase" style={{ fontSize: pausedFont }}>
+          <span className="uppercase" style={{ fontSize: pausedFont, color: 'var(--timer-color)' }}>
             Paused
           </span>
         )}
@@ -233,15 +239,17 @@ export const ScoreboardDisplay: React.FC<ScoreboardDisplayProps> = ({
 
       <div className="flex flex-col flex-1 justify-between">
         <div className="flex items-center justify-between">
-          <TeamLogo src={gameState.homeTeam.logo} size={logoSize} />
+          <div style={{ color: 'var(--team-a-color)' }}>
+            <TeamLogo src={gameState.homeTeam.logo} size={logoSize} />
+          </div>
           <div className="flex flex-col items-center">
             {showScore && (
-              <span className="font-mono font-bold leading-none" style={{ fontSize: scoreFont }}>
+              <span className="font-mono font-bold leading-none" style={{ fontSize: scoreFont, color: 'var(--team-a-color)' }}>
                 {String(gameState.homeTeam.score).padStart(2, '0')}
               </span>
             )}
             {showFouls && (
-              <span className="font-mono leading-none" style={{ fontSize: foulsFont }}>
+              <span className="font-mono leading-none" style={{ fontSize: foulsFont, color: 'var(--team-a-color)' }}>
                 F:{gameState.homeTeam.fouls}
               </span>
             )}
@@ -249,22 +257,24 @@ export const ScoreboardDisplay: React.FC<ScoreboardDisplayProps> = ({
           <span
             ref={homeNameRef}
             className="font-semibold leading-none truncate text-right flex-1 ml-2"
-            style={{ fontSize: teamFont }}
+            style={{ fontSize: teamFont, color: 'var(--team-a-color)' }}
           >
             {gameState.homeTeam.name}
           </span>
         </div>
 
         <div className="flex items-center justify-between mt-2">
-          <TeamLogo src={gameState.awayTeam.logo} size={logoSize} />
+          <div style={{ color: 'var(--team-b-color)' }}>
+            <TeamLogo src={gameState.awayTeam.logo} size={logoSize} />
+          </div>
           <div className="flex flex-col items-center">
             {showScore && (
-              <span className="font-mono font-bold leading-none" style={{ fontSize: scoreFont }}>
+              <span className="font-mono font-bold leading-none" style={{ fontSize: scoreFont, color: 'var(--team-b-color)' }}>
                 {String(gameState.awayTeam.score).padStart(2, '0')}
               </span>
             )}
             {showFouls && (
-              <span className="font-mono leading-none" style={{ fontSize: foulsFont }}>
+              <span className="font-mono leading-none" style={{ fontSize: foulsFont, color: 'var(--team-b-color)' }}>
                 F:{gameState.awayTeam.fouls}
               </span>
             )}
@@ -272,14 +282,14 @@ export const ScoreboardDisplay: React.FC<ScoreboardDisplayProps> = ({
           <span
             ref={awayNameRef}
             className="font-semibold leading-none truncate text-right flex-1 ml-2"
-            style={{ fontSize: teamFont }}
+            style={{ fontSize: teamFont, color: 'var(--team-b-color)' }}
           >
             {gameState.awayTeam.name}
           </span>
         </div>
       </div>
 
-      <div className="flex items-center justify-center">
+      <div className="flex items-center justify-center" style={{ color: 'var(--timer-color)' }}>
         <TournamentLogo src={gameState.tournamentLogo} width={compWidth} height={compHeight} />
       </div>
     </div>

--- a/src/components/ScoreboardDisplayPage.tsx
+++ b/src/components/ScoreboardDisplayPage.tsx
@@ -36,7 +36,9 @@ export const ScoreboardDisplayPage: React.FC<Props> = ({ gameState }) => {
     timerMode: (params.get('timerMode') as 'elapsed' | 'remaining') || 'elapsed',
     layout: (params.get('layout') as 'horizontal' | 'vertical') || 'horizontal',
     bgColor: params.get('bgColor') ? decodeURIComponent(params.get('bgColor') as string) : '#1d4ed8',
-    textColor: params.get('textColor') ? decodeURIComponent(params.get('textColor') as string) : '#ffffff',
+    teamAColor: params.get('teamAColor') ? decodeURIComponent(params.get('teamAColor') as string) : '#3b82f6',
+    teamBColor: params.get('teamBColor') ? decodeURIComponent(params.get('teamBColor') as string) : '#ef4444',
+    timerColor: params.get('timerColor') ? decodeURIComponent(params.get('timerColor') as string) : '#ffffff',
   } as const;
 
   return (


### PR DESCRIPTION
## Summary
- allow separate Team A, Team B, Timer, and background color selection
- apply per-team and timer colors across scoreboard display
- include color settings in shareable scoreboard link

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_689eb2674eb0832da5932c5311a0c319