### PR TITLE
Add scoreboard display route

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A modern React + TypeScript application for managing futsal matches with a polis
 The UI automatically follows your system theme. Switch your operating system or browser to dark mode to experience the darker palette.
 
 ### Routes
-Navigate between the dashboard and stats tracker views using the on-screen controls or by visiting the respective routes (`/dashboard`, `/stats`).
+Navigate between the dashboard, stats tracker, and scoreboard views using the on-screen controls or by visiting the respective routes (`/dashboard`, `/stats`, `/scoreboard`).
 
 ### Animations
 Key interface elements such as the live indicator and score updates use smooth animations to improve readability. These animations are powered by Tailwind CSS utility classes.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,8 +8,9 @@ import { ControlPanelButton } from './components/ControlPanelButton';
 import { ThemeToggle } from './components/ThemeToggle';
 import { SettingsProvider } from './hooks/SettingsProvider';
 import { SettingsPage } from './components/SettingsPage';
+import { ScoreboardDisplay } from './components/ScoreboardDisplay';
 
-type ViewMode = 'dashboard' | 'stats' | 'settings';
+type ViewMode = 'dashboard' | 'stats' | 'settings' | 'scoreboard';
 
 type GameStateType = ReturnType<typeof useGameState>;
 
@@ -31,6 +32,16 @@ const StatsView: React.FC<ViewProps> = ({ gameState }) => {
         undo={gameState.undo}
         redo={gameState.redo}
       />
+      <ControlPanelButton onClick={() => navigate('/dashboard')} />
+    </div>
+  );
+};
+
+const ScoreboardView: React.FC<ViewProps> = ({ gameState }) => {
+  const navigate = useNavigate();
+  return (
+    <div className="relative w-full h-screen">
+      <ScoreboardDisplay gameState={gameState.gameState} />
       <ControlPanelButton onClick={() => navigate('/dashboard')} />
     </div>
   );
@@ -95,6 +106,7 @@ const MainLayout: React.FC<MainLayoutProps> = ({ gameState, theme, toggleTheme }
             />
           }
         />
+        <Route path="/scoreboard" element={<ScoreboardView gameState={gameState} />} />
         <Route path="/stats" element={<StatsView gameState={gameState} />} />
         <Route path="/settings" element={<SettingsView gameState={gameState} theme={theme} toggleTheme={toggleTheme} />} />
         <Route path="/" element={<Navigate to="/dashboard" replace />} />

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -12,6 +12,7 @@ import {
   Undo2,
   Redo2,
   Settings,
+  Tv,
 } from 'lucide-react';
 import { useSettings } from '../hooks/useSettings';
 import { GamePresetSelector } from './GamePresetSelector';
@@ -29,7 +30,7 @@ interface DashboardProps {
   addPlayer: (team: 'home' | 'away', name: string, role: 'starter' | 'substitute') => void;
   removePlayer: (team: 'home' | 'away', playerId: string) => void;
   onViewChange: (
-    view: 'dashboard' | 'stats' | 'settings'
+    view: 'dashboard' | 'stats' | 'settings' | 'scoreboard'
   ) => void;
 }
 
@@ -179,6 +180,13 @@ export const Dashboard: React.FC<DashboardProps> = ({
           <div className="flex justify-between items-center py-4">
             <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Futsal Control Dashboard</h1>
             <div className="flex gap-3">
+              <button
+                onClick={() => onViewChange('scoreboard')}
+                className="inline-flex items-center gap-2 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors"
+              >
+                <Tv className="w-4 h-4" />
+                Scoreboard
+              </button>
               <button
                 onClick={() => onViewChange('stats')}
                 className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"


### PR DESCRIPTION
## Summary
- expose scoreboard display on new `/scoreboard` route with control panel access
- add navigation button from dashboard to scoreboard
- document scoreboard route in README

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f5f6c5d4c832db58735a6608f7f42